### PR TITLE
🐛 fix: Masonry 스토리북 element 개수 수정(1024 -> 20개)

### DIFF
--- a/src/components/common/Masonry/Masonry.stories.tsx
+++ b/src/components/common/Masonry/Masonry.stories.tsx
@@ -20,7 +20,7 @@ const sampleImages = [
   { url: "https://picsum.photos/236/354", width: 236, height: 354 },
 ];
 
-const memes = Array.from(Array(1024).keys()).map((id) => {
+const memes = Array.from(Array(20).keys()).map((id) => {
   const randomIndex = Math.floor(Math.random() * sampleImages.length);
   const { url, width, height } = sampleImages[randomIndex];
   return {


### PR DESCRIPTION
## 📮 관련 이슈
- resolved: #이슈번호

## ⛳️ 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

## 🌱 PR 포인트
- Masonry 스토리북에서 아래 오류 발생
  - Masonry 스토리북에서 렌더링하는 element의 개수가 너무 많아서 기존 1024개에서 20개로 줄임
![스크린샷 2023-03-27 01 52 32](https://user-images.githubusercontent.com/33178048/227791335-50464e43-e3fe-4093-9f06-3ca74555a691.png)

## 📸 스크린샷
|스크린샷|스크린샷|
|:--:|:--:|
|파일첨부바람|파일첨부바람|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->