### PR TITLE
♻️ 즐겨찾기 태그 api , 추가/삭제 로직 반영

### DIFF
--- a/mocks/handlers/tags/data.ts
+++ b/mocks/handlers/tags/data.ts
@@ -289,3 +289,16 @@ export const mainTags = [
     },
   ],
 ];
+
+export const favoriteTags = [
+  {
+    tagId: 321,
+    name: "박명수",
+    isFav: true,
+  },
+  {
+    tagId: 322,
+    name: "무한도전",
+    isFav: true,
+  },
+];

--- a/mocks/handlers/tags/index.ts
+++ b/mocks/handlers/tags/index.ts
@@ -40,6 +40,19 @@ export const getMemeTagsById = rest.get(
   },
 );
 
+export const getFavoriteTags = rest.get(
+  `${process.env.NEXT_PUBLIC_API_URL}/tags/favs`,
+  async (req, res, ctx) => {
+    return res(
+      ctx.delay(300),
+      ctx.status(200),
+      ctx.json({
+        tags: MOCK_DATA.favoriteTags,
+      }),
+    );
+  },
+);
+
 export const postFavoriteTag = rest.post(
   `${process.env.NEXT_PUBLIC_API_URL}/tags/:tagId/fav`,
   async (req, res, ctx) => {

--- a/src/application/hooks/api/tags/index.ts
+++ b/src/application/hooks/api/tags/index.ts
@@ -117,18 +117,22 @@ export const usePostFavoriteTag = (name: string) => {
         ReturnType<typeof api.tags.getTagInfo>
       >;
 
-      queryClient.setQueryData(QUERY_KEYS.getFavoriteTags, (old) => {
-        const newTags = [
-          ...(old as Awaited<ReturnType<typeof api.tags.getFavoriteTags>>).tags,
-          {
-            tagId: id,
-            name: name,
-            isFav: true,
-          },
-        ];
+      queryClient.setQueryData<Awaited<ReturnType<typeof api.tags.getFavoriteTags>>>(
+        QUERY_KEYS.getFavoriteTags,
+        (old) => {
+          if (!old) return;
+          const newTags = [
+            ...old.tags,
+            {
+              tagId: id,
+              name: name,
+              isFav: true,
+            },
+          ];
 
-        return { tags: newTags };
-      });
+          return { tags: newTags };
+        },
+      );
 
       queryClient.setQueryData(QUERY_KEYS.getTagInfo(id), (old) => ({
         ...(old as Awaited<ReturnType<typeof api.tags.getCategoryWithTags>>),
@@ -160,12 +164,14 @@ export const useDeleteFavoriteTag = (wait = 0) => {
         ReturnType<typeof api.tags.getTagInfo>
       >;
 
-      queryClient.setQueryData(QUERY_KEYS.getFavoriteTags, (old) => {
-        const newTags = (old as Awaited<ReturnType<typeof api.tags.getFavoriteTags>>).tags.filter(
-          (tag) => tag.tagId !== id,
-        );
-        return { tags: newTags };
-      });
+      queryClient.setQueryData<Awaited<ReturnType<typeof api.tags.getFavoriteTags>>>(
+        QUERY_KEYS.getFavoriteTags,
+        (old) => {
+          if (!old) return;
+          const newTags = old.tags.filter((tag) => tag.tagId !== id);
+          return { tags: newTags };
+        },
+      );
 
       queryClient.setQueryData(QUERY_KEYS.getTagInfo(id), (old) => ({
         ...(old as Awaited<ReturnType<typeof api.tags.getFavoriteTags>>),

--- a/src/application/hooks/api/tags/index.ts
+++ b/src/application/hooks/api/tags/index.ts
@@ -105,15 +105,15 @@ export const useGetFavoriteTags = (
   return { favoriteCategory: favoriteCategory, favoriteTags: data?.tags };
 };
 
-export const usePostFavoriteTag = (name: string) => {
+export const usePostFavoriteTag = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: api.tags.postFavoriteTag,
-    onMutate: async (id) => {
-      await queryClient.cancelQueries({ queryKey: QUERY_KEYS.getTagInfo(id) });
+    onMutate: async ({ tagId, name }) => {
+      await queryClient.cancelQueries({ queryKey: QUERY_KEYS.getTagInfo(tagId) });
 
-      const previousTagInfo = queryClient.getQueryData(QUERY_KEYS.getTagInfo(id)) as Awaited<
+      const previousTagInfo = queryClient.getQueryData(QUERY_KEYS.getTagInfo(tagId)) as Awaited<
         ReturnType<typeof api.tags.getTagInfo>
       >;
 
@@ -124,7 +124,7 @@ export const usePostFavoriteTag = (name: string) => {
           const newTags = [
             ...old.tags,
             {
-              tagId: id,
+              tagId: tagId,
               name: name,
               isFav: true,
             },
@@ -134,7 +134,7 @@ export const usePostFavoriteTag = (name: string) => {
         },
       );
 
-      queryClient.setQueryData(QUERY_KEYS.getTagInfo(id), (old) => ({
+      queryClient.setQueryData(QUERY_KEYS.getTagInfo(tagId), (old) => ({
         ...(old as Awaited<ReturnType<typeof api.tags.getCategoryWithTags>>),
         isFav: true,
       }));
@@ -142,8 +142,8 @@ export const usePostFavoriteTag = (name: string) => {
       return { previousTagInfo };
     },
 
-    onError: (err, id, context) => {
-      queryClient.setQueryData(QUERY_KEYS.getTagInfo(id), context?.previousTagInfo);
+    onError: (err, { tagId }, context) => {
+      queryClient.setQueryData(QUERY_KEYS.getTagInfo(tagId), context?.previousTagInfo);
     },
   });
 };

--- a/src/application/hooks/api/tags/index.ts
+++ b/src/application/hooks/api/tags/index.ts
@@ -84,11 +84,13 @@ export const useGetTagInfo = (
 export const fetchTagInfo = (tagId: number, queryClient: QueryClient) =>
   queryClient.fetchQuery(QUERY_KEYS.getTagInfo(tagId), () => api.tags.getTagInfo(tagId));
 
-export const useGetFavoriteTags = ({ enabled = false }: { enabled?: boolean }) => {
+export const useGetFavoriteTags = (
+  options: Pick<UseQueryOptions, "enabled"> = { enabled: false },
+) => {
   const { data, ...rest } = useQuery<GetFavoriteTagsResponse>({
     queryKey: QUERY_KEYS.getFavoriteTags,
     queryFn: () => api.tags.getFavoriteTags(),
-    enabled: enabled,
+    ...options,
   });
 
   const favoriteCategory = [

--- a/src/application/hooks/api/tags/queryKey.ts
+++ b/src/application/hooks/api/tags/queryKey.ts
@@ -2,6 +2,7 @@ export const QUERY_KEYS = {
   getPopularTags: ["getPopularTags"],
   getTagSearch: (debouncedValue: string) => ["getTagSearch", debouncedValue],
   getCategoryWithTags: ["getCategoryWithTags"],
+  getFavoriteTags: ["getFavoriteTags"],
   getMemeTagsById: (id: string) => ["getMemeTagsById", id],
   getTagInfo: (tagId: number) => ["getTagInfo", tagId],
 } as const;

--- a/src/components/tags/TagCategory/CategoryContent.tsx
+++ b/src/components/tags/TagCategory/CategoryContent.tsx
@@ -47,7 +47,7 @@ export const CategoryContent = () => {
     },
   });
 
-  if (favoriteTags?.length) data?.unshift(favoriteItem);
+  if (favoriteTags?.length && isLogin) data?.unshift(favoriteItem);
 
   const onClickItem = (tagId: number) => {
     setDrawerOpen(false);

--- a/src/components/tags/TagCategory/CategoryContent.tsx
+++ b/src/components/tags/TagCategory/CategoryContent.tsx
@@ -47,7 +47,7 @@ export const CategoryContent = () => {
     },
   });
 
-  if (favoriteTags) data?.unshift(favoriteItem);
+  if (favoriteTags?.length) data?.unshift(favoriteItem);
 
   const onClickItem = (tagId: number) => {
     setDrawerOpen(false);

--- a/src/components/tags/TagCategory/CategoryContent.tsx
+++ b/src/components/tags/TagCategory/CategoryContent.tsx
@@ -1,7 +1,13 @@
 import { Content, Header, Item, Root, Trigger } from "@radix-ui/react-accordion";
 import { useRouter } from "next/router";
 
-import { useAuth, useGetCategoryWithTag, useToast } from "@/application/hooks";
+import {
+  useAuth,
+  useDeleteFavoriteTag,
+  useGetCategoryWithTag,
+  useGetFavoriteTags,
+  useToast,
+} from "@/application/hooks";
 import { PATH } from "@/application/util";
 import { useSetDrawerContext } from "@/components/common/Drawer";
 import { Icon } from "@/components/common/Icon";
@@ -12,23 +18,23 @@ const TAG_DELETE_DELAY = 1500;
 
 export const CategoryContent = () => {
   const router = useRouter();
-  const { isLoading } = useAuth();
+  const { isLoading, isLogin } = useAuth();
   const setDrawerOpen = useSetDrawerContext();
   const { show, close } = useToast();
 
-  /**
-   * NOTE : 카테고리 태그 불러오는 api 와 즐겨찾기 태그 불러오는 api 가 분리돼서 수정될 예정
-   */
+  const { favoriteCategory, favoriteTags } = useGetFavoriteTags({ enabled: isLogin });
+
+  const favoriteItem = {
+    name: FAVORITE_ID,
+    id: FAVORITE_ID,
+    icon: "/icon/star.svg",
+    categories: favoriteCategory,
+    maintags: [],
+  };
+
   const { data } = useGetCategoryWithTag({
     enabled: !isLoading,
     select: ({ mainCategories, mainTags }) => {
-      // const favoriteItem = {
-      //   name: FAVORITE_ID,
-      //   id: FAVORITE_ID,
-      //   icon: "/icon/star.svg",
-      //   categories: maincategories.map((maincategory) => maincategory.categories.categories).flat(),
-      // };
-
       const restItem = mainCategories.map((maincategory) => ({
         name: maincategory.name,
         id: String(maincategory.mainCategoryId),
@@ -37,51 +43,46 @@ export const CategoryContent = () => {
         maintags: mainTags[maincategory.mainCategoryId - 1] || [],
       }));
 
-      // if (favoriteItem.categories.length) restItem.unshift(favoriteItem);
-
       return restItem;
     },
   });
+
+  if (favoriteTags) data?.unshift(favoriteItem);
 
   const onClickItem = (tagId: number) => {
     setDrawerOpen(false);
     router.push(PATH.getExploreByTagPath(tagId));
   };
 
-  /**
-   * NOTE: 즐겨찾기 태그 불러오는 api 작업하면서 아마 수정될 예정
-   * 현재는 CategoryContent 에서 에러나므로 즐겨찾기 관련 로직은 주석 처리
-   */
+  const { mutate: deleteFavoriteTag, onCancel } = useDeleteFavoriteTag(TAG_DELETE_DELAY);
 
-  // const { mutate: deleteFavoriteTag, onCancel } = useDeleteFavoriteTag(TAG_DELETE_DELAY);
+  const handleDeleteItem = async (tagId: number) => {
+    show(
+      (id) => (
+        <>
+          <div className="grow">태그가 삭제 되었습니다.</div>
+          <button
+            className="justify-self-end text-14-semibold-140 leading-none text-gray-400"
+            onClick={() => {
+              onCancel();
+              close({ id, duration: 0 });
+              show("태그 삭제를 취소 하였습니다.");
+            }}
+          >
+            삭제 취소
+          </button>
+        </>
+      ),
+      { duration: TAG_DELETE_DELAY },
+    );
 
-  // const handleDeleteItem = async (tagId: number) => {
-  //   show(
-  //     (id) => (
-  //       <>
-  //         <div className="grow">태그가 삭제 되었습니다.</div>
-  //         <button
-  //           className="justify-self-end text-14-semibold-140 leading-none text-gray-400"
-  //           onClick={() => {
-  //             onCancel();
-  //             close({ id, duration: 0 });
-  //             show("태그 삭제를 취소 하였습니다.");
-  //           }}
-  //         >
-  //           삭제 취소
-  //         </button>
-  //       </>
-  //     ),
-  //     { duration: TAG_DELETE_DELAY },
-  //   );
-
-  //   deleteFavoriteTag(tagId, {
-  //     onError: (err) => {
-  //       if (err instanceof Error && err.name === "CanceledError") return;
-  //       show("태그 삭제가 실패하였습니다.");
-  //     },
-  //   });
-  // };
+    deleteFavoriteTag(tagId, {
+      onError: (err) => {
+        if (err instanceof Error && err.name === "CanceledError") return;
+        show("태그 삭제가 실패하였습니다.");
+      },
+    });
+  };
 
   return (
     <Root collapsible className="w-full min-w-300" defaultValue={FAVORITE_ID} type="single">
@@ -123,7 +124,10 @@ export const CategoryContent = () => {
                           <div className="grow text-left">{tag.name}</div>
                         </button>
                         {item.id === FAVORITE_ID && (
-                          <button className="flex h-40 w-40 items-center justify-center rounded-full hover:bg-gray-100 [&_*]:stroke-gray-600 [&_*]:hover:stroke-black">
+                          <button
+                            className="flex h-40 w-40 items-center justify-center rounded-full hover:bg-gray-100 [&_*]:stroke-gray-600 [&_*]:hover:stroke-black"
+                            onClick={() => handleDeleteItem(tag.tagId)}
+                          >
                             <Icon height={24} name="cancel" width={24} />
                           </button>
                         )}

--- a/src/components/tags/TagCategory/CategoryContent.tsx
+++ b/src/components/tags/TagCategory/CategoryContent.tsx
@@ -9,7 +9,6 @@ import {
   useToast,
 } from "@/application/hooks";
 import { PATH } from "@/application/util";
-import { useSetDrawerContext } from "@/components/common/Drawer";
 import { Icon } from "@/components/common/Icon";
 import { Photo } from "@/components/common/Photo";
 
@@ -19,7 +18,6 @@ const TAG_DELETE_DELAY = 1500;
 export const CategoryContent = () => {
   const router = useRouter();
   const { isLoading, isLogin } = useAuth();
-  const setDrawerOpen = useSetDrawerContext();
   const { show, close } = useToast();
 
   const { favoriteCategory, favoriteTags } = useGetFavoriteTags({ enabled: isLogin });
@@ -50,7 +48,6 @@ export const CategoryContent = () => {
   if (favoriteTags?.length && isLogin) data?.unshift(favoriteItem);
 
   const onClickItem = (tagId: number) => {
-    setDrawerOpen(false);
     router.push(PATH.getExploreByTagPath(tagId));
   };
 

--- a/src/components/tags/TagFavoriteButton/TagBookmarkButton.tsx
+++ b/src/components/tags/TagFavoriteButton/TagBookmarkButton.tsx
@@ -1,4 +1,10 @@
-import { useAuth, useGetTagInfo, useToast } from "@/application/hooks";
+import {
+  useAuth,
+  useDeleteFavoriteTag,
+  useGetTagInfo,
+  usePostFavoriteTag,
+  useToast,
+} from "@/application/hooks";
 import { Button } from "@/components/common/Button";
 import { Icon } from "@/components/common/Icon";
 
@@ -13,35 +19,25 @@ export const TagBookmarkButton = ({ tagId }: Props) => {
   const { validate, isLoading } = useAuth();
   const { data, isFetchedAfterMount } = useGetTagInfo(tagId, { enabled: !isLoading });
 
-  /**
-   * NOTE: 즐겨찾기 api 가 현재 CategoryContent 에서 에러나므로 즐겨찾기 관련 로직은 주석 처리
-   * 추후 즐겨찾기 api가 수정되면 주석 해제 예정
-   */
-  // const { mutate: saveMutation } = usePostFavoriteTag();
-  // const { mutate: deleteMutation } = useDeleteFavoriteTag();
-
+  const { mutate: saveMutation } = usePostFavoriteTag(data?.name || "");
+  const { mutate: deleteMutation } = useDeleteFavoriteTag();
   if (!isFetchedAfterMount || !data) return null;
   const { isFav } = data;
+  const handleSaveBookmark = () => {
+    saveMutation(tagId, {
+      onSuccess: () => show("즐겨찾기에 추가했습니다."),
+      onError: () => show("다시 시도해 주세요."),
+    });
+  };
 
-  /**
-   * NOTE: 즐겨찾기 api 가 현재 CategoryContent 에서 에러나므로 즐겨찾기 관련 로직은 주석 처리
-   * 추후 즐겨찾기 api가 수정되면 주석 해제 예정
-   */
-  // const handleSaveBookmark = () => {
-  //   saveMutation(tagId, {
-  //     onSuccess: () => show("즐겨찾기에 추가했습니다."),
-  //     onError: () => show("다시 시도해 주세요."),
-  //   });
-  // };
+  const handleDeleteBookmark = () => {
+    deleteMutation(tagId, {
+      onSuccess: () => show("즐겨찾기에서 해제했습니다."),
+      onError: () => show("다시 시도해 주세요."),
+    });
+  };
 
-  // const handleDeleteBookmark = () => {
-  //   deleteMutation(tagId, {
-  //     onSuccess: () => show("즐겨찾기에서 해제했습니다."),
-  //     onError: () => show("다시 시도해 주세요."),
-  //   });
-  // };
-
-  // const handleClick = isFav ? handleDeleteBookmark : handleSaveBookmark;
+  const handleClick = isFav ? handleDeleteBookmark : handleSaveBookmark;
 
   return (
     <div className="fixed bottom-32 right-18 text-center">
@@ -50,7 +46,7 @@ export const TagBookmarkButton = ({ tagId }: Props) => {
         className={`${
           isFav ? "bg-primary-300 [&_*]:fill-[#fddd71]" : "bg-gray-800"
         } ${animation} peer mb-3 h-60 w-60 rounded-full active:bg-black`}
-        onClick={validate()}
+        onClick={validate(handleClick)}
       >
         <Icon height={28} name="star" width={28} />
       </Button>

--- a/src/components/tags/TagFavoriteButton/TagBookmarkButton.tsx
+++ b/src/components/tags/TagFavoriteButton/TagBookmarkButton.tsx
@@ -19,15 +19,18 @@ export const TagBookmarkButton = ({ tagId }: Props) => {
   const { validate, isLoading } = useAuth();
   const { data, isFetchedAfterMount } = useGetTagInfo(tagId, { enabled: !isLoading });
 
-  const { mutate: saveMutation } = usePostFavoriteTag(data?.name || "");
+  const { mutate: saveMutation } = usePostFavoriteTag();
   const { mutate: deleteMutation } = useDeleteFavoriteTag();
   if (!isFetchedAfterMount || !data) return null;
   const { isFav } = data;
   const handleSaveBookmark = () => {
-    saveMutation(tagId, {
-      onSuccess: () => show("즐겨찾기에 추가했습니다."),
-      onError: () => show("다시 시도해 주세요."),
-    });
+    saveMutation(
+      { tagId: tagId, name: data.name },
+      {
+        onSuccess: () => show("즐겨찾기에 추가했습니다."),
+        onError: () => show("다시 시도해 주세요."),
+      },
+    );
   };
 
   const handleDeleteBookmark = () => {

--- a/src/infra/api/tags/index.ts
+++ b/src/infra/api/tags/index.ts
@@ -56,7 +56,7 @@ export class TagApi {
     return this.api.get<GetFavoriteTagsResponse>("/tags/favs").then((response) => response.data);
   };
 
-  postFavoriteTag = (tagId: number) => {
+  postFavoriteTag = ({ tagId, name }: { tagId: number; name: string }) => {
     return this.api.post(`/tags/${tagId}/fav`).then((response) => response.data);
   };
 

--- a/src/infra/api/tags/index.ts
+++ b/src/infra/api/tags/index.ts
@@ -2,6 +2,7 @@ import type { AxiosInstance } from "axios";
 
 import type {
   GetCategoryByTagResponse,
+  GetFavoriteTagsResponse,
   GetMemeTagsByIdResponse,
   GetTagInfoResponse,
 } from "./types";
@@ -49,6 +50,10 @@ export class TagApi {
 
   getTagInfo = (tagId: number) => {
     return this.api.get<GetTagInfoResponse>(`/tags/${tagId}`).then((response) => response.data);
+  };
+
+  getFavoriteTags = () => {
+    return this.api.get<GetFavoriteTagsResponse>("/tags/favs").then((response) => response.data);
   };
 
   postFavoriteTag = (tagId: number) => {

--- a/src/infra/api/tags/types.ts
+++ b/src/infra/api/tags/types.ts
@@ -3,6 +3,7 @@ export interface Tag {
   name: string;
   viewCount: number;
   categoryId: number;
+  isFav?: boolean;
 }
 
 export interface GetPopularTagsResponse {
@@ -21,7 +22,7 @@ export interface Category {
   categoryId: number;
   name: string;
   priority: number;
-  tags: Pick<Tag, "tagId" | "name">[];
+  tags: Pick<Tag, "tagId" | "name" | "isFav">[];
 }
 
 export interface GetCategoryByTagResponse {
@@ -37,3 +38,4 @@ export interface GetCategoryByTagResponse {
 }
 
 export type GetTagInfoResponse = Tag & { isFav: boolean };
+export type GetFavoriteTagsResponse = Pick<Category, "tags">;


### PR DESCRIPTION

## 📮 관련 이슈
- resolved: #이슈번호

## ⛳️ 작업 내용
- 즐겨찾기 태그 api 추가
- 즐겨찾기 추가/삭제 로직 반영

## 🌱 PR 포인트
### 1. 즐겨찾기 태그 카테고리와 태그 카테고리
- 즐겨찾기 태그 리스폰스가 태그 카테고리 리스폰스와는 달라서
-  서로 데이터 인터페이스를 맞춰주기 위해 임의의 **favoriteCategory** 를 만들었습니다.
```ts
//useGetFavoriteTags 에서 return 할때 favoriteCategory 로 가공해서 넘겨주기

const favoriteCategory = [
    {
      categoryId: 0,
      name: "",
      priority: 0,
      tags: data?.tags || [],
    },
  ];
```
```ts
//useGetFavoriteTags 에서 favoriteCategory 를 받아 favoriteItem 에 추가

const { favoriteCategory, favoriteTags } = useGetFavoriteTags({ enabled: isLogin });

  const favoriteItem = {
    name: FAVORITE_ID,
    id: FAVORITE_ID,
    icon: "/icon/star.svg",
    categories: favoriteCategory,
    maintags: [],
  };
```

### 2.  즐겨찾기/추가 삭제 로직
- 기존에는 `setQueryData` 를 **태그 카테고리 api** 에서만 적용 -> **즐겨찾기 태그 api, 태그 카테고리 api** 에도 업데이트 적용
   - 하지만 즐겨찾기한 태그가 어떤 카테고리에 속하는지 모르는 상황이라서(리스폰스 값에 없음) 
   - 태그 카테고리 api 에는  `setQueryData` 에는 적용하지 못했습니다...
   **생각나는 해결방법**
   1. 서버에서 즐겨찾기 태그 리스폰스 값에도 카테고리를 내려주기
   2. `setQueryData` 대신 `invalidateQueries` 적용하기 -> Optimistic UI 적용 안됨
   3. 다른 좋은 방법이 있다면 알려주시긘...
## 📸 스크린샷
|![ezgif com-video-to-gif](https://user-images.githubusercontent.com/101736358/233459899-1d4ee868-48cd-4846-98c0-9fb91acf8f36.gif)|스크린샷|
|:--:|:--:|
|파일첨부바람|파일첨부바람|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->