### PR TITLE
♻️ refactor : 즐겨찾기 UI  및 로직 분리

### DIFF
--- a/src/application/hooks/api/tags/index.ts
+++ b/src/application/hooks/api/tags/index.ts
@@ -93,16 +93,7 @@ export const useGetFavoriteTags = (
     ...options,
   });
 
-  const favoriteCategory = [
-    {
-      categoryId: 0,
-      name: "",
-      priority: 0,
-      tags: data?.tags || [],
-    },
-  ];
-
-  return { favoriteCategory: favoriteCategory, favoriteTags: data?.tags };
+  return { favoriteTags: data?.tags };
 };
 
 export const usePostFavoriteTag = () => {

--- a/src/application/hooks/api/tags/index.ts
+++ b/src/application/hooks/api/tags/index.ts
@@ -41,19 +41,16 @@ export const useGetTagSearch = (value: string) => {
 
 /**
  * @desc
- * Navigation Drawer (SideBar) 카테고리/태그
+ * Tag Category 에 즐겨찾기를 제외한 태그들
  */
 export const useGetCategoryWithTag = <T>({
   select,
-  enabled = true,
 }: {
   select: QuerySelectOption<T, typeof api.tags.getCategoryWithTags>;
-  enabled?: boolean;
 }) =>
   useQuery({
     queryKey: QUERY_KEYS.getCategoryWithTags,
     queryFn: api.tags.getCategoryWithTags,
-    enabled,
     select,
   });
 

--- a/src/components/tags/TagCategory/CategoryContent.tsx
+++ b/src/components/tags/TagCategory/CategoryContent.tsx
@@ -1,36 +1,19 @@
 import { Content, Header, Item, Root, Trigger } from "@radix-ui/react-accordion";
 import { useRouter } from "next/router";
 
-import {
-  useAuth,
-  useDeleteFavoriteTag,
-  useGetCategoryWithTag,
-  useGetFavoriteTags,
-  useToast,
-} from "@/application/hooks";
+import { useAuth, useGetCategoryWithTag } from "@/application/hooks";
 import { PATH } from "@/application/util";
 import { Icon } from "@/components/common/Icon";
 import { Photo } from "@/components/common/Photo";
 
+import { FavoriteCategory } from "./FavoriteCategory";
 import { SlotCategory } from "./SlotCategory";
 
 const FAVORITE_ID = "북마크";
-const TAG_DELETE_DELAY = 1500;
 
 export const CategoryContent = () => {
   const router = useRouter();
-  const { isLoading, isLogin } = useAuth();
-  const { show, close } = useToast();
-
-  const { favoriteCategory, favoriteTags } = useGetFavoriteTags({ enabled: isLogin });
-
-  const favoriteItem = {
-    name: FAVORITE_ID,
-    id: FAVORITE_ID,
-    icon: "/icon/star.svg",
-    categories: favoriteCategory,
-    mainTags: [],
-  };
+  const { isLoading } = useAuth();
 
   const { data } = useGetCategoryWithTag({
     enabled: !isLoading,
@@ -47,53 +30,19 @@ export const CategoryContent = () => {
     },
   });
 
-  if (favoriteTags?.length && isLogin) data?.unshift(favoriteItem);
-
   const onClickItem = (tagId: number) => {
     router.push(PATH.getExploreByTagPath(tagId));
   };
 
-  const { mutate: deleteFavoriteTag, onCancel } = useDeleteFavoriteTag(TAG_DELETE_DELAY);
-
-  const handleDeleteItem = async (tagId: number) => {
-    show(
-      (id) => (
-        <>
-          <div className="grow">태그가 삭제 되었습니다.</div>
-          <button
-            className="justify-self-end text-14-semibold-140 leading-none text-gray-400"
-            onClick={() => {
-              onCancel();
-              close({ id, duration: 0 });
-              show("태그 삭제를 취소 하였습니다.");
-            }}
-          >
-            삭제 취소
-          </button>
-        </>
-      ),
-      { duration: TAG_DELETE_DELAY },
-    );
-
-    deleteFavoriteTag(tagId, {
-      onError: (err) => {
-        if (err instanceof Error && err.name === "CanceledError") return;
-        show("태그 삭제가 실패하였습니다.");
-      },
-    });
-  };
-
   return (
     <Root collapsible className="w-full min-w-300" defaultValue={FAVORITE_ID} type="single">
+      <FavoriteCategory />
       {data?.map((item) => (
         <>
-          {item.id === "북마크" && (
-            <div className="py-8 text-18-bold-140">당신이 즐겨찾는 태그</div>
-          )}
-          {item.id === "1" && (
+          {item.name === "사용자" && (
             <div className="py-8 text-18-bold-140">이럴 때 이런 밈은 어때요?</div>
           )}
-          {item.id === "4" && <div className="py-8 text-18-bold-140">밈 바로 찾기</div>}
+          {item.name === "콘텐츠" && <div className="py-8 text-18-bold-140">밈 바로 찾기</div>}
           <Item key={item.id} value={item.id}>
             <Header className="py-4">
               <Trigger className="flex w-full items-center justify-between gap-8 rounded-full px-4 py-12 text-16-semibold-140 [&>span>#chevronDown]:data-[state=open]:rotate-180">
@@ -128,14 +77,6 @@ export const CategoryContent = () => {
                         >
                           <div className="grow text-left">{tag.name}</div>
                         </button>
-                        {item.id === FAVORITE_ID && (
-                          <button
-                            className="flex h-40 w-40 items-center justify-center rounded-full hover:bg-gray-100 [&_*]:stroke-gray-600 [&_*]:hover:stroke-black"
-                            onClick={() => handleDeleteItem(tag.tagId)}
-                          >
-                            <Icon height={24} name="cancel" width={24} />
-                          </button>
-                        )}
                       </li>
                     ))}
                   </>

--- a/src/components/tags/TagCategory/CategoryContent.tsx
+++ b/src/components/tags/TagCategory/CategoryContent.tsx
@@ -1,7 +1,7 @@
 import { Content, Header, Item, Root, Trigger } from "@radix-ui/react-accordion";
 import { useRouter } from "next/router";
 
-import { useAuth, useGetCategoryWithTag } from "@/application/hooks";
+import { useGetCategoryWithTag } from "@/application/hooks";
 import { PATH } from "@/application/util";
 import { Icon } from "@/components/common/Icon";
 import { Photo } from "@/components/common/Photo";
@@ -12,10 +12,8 @@ import { SlotCategory } from "./SlotCategory";
 
 export const CategoryContent = () => {
   const router = useRouter();
-  const { isLoading } = useAuth();
 
   const { data } = useGetCategoryWithTag({
-    enabled: !isLoading,
     select: ({ mainCategories, mainTags }) => {
       const restItem = mainCategories.map((maincategory) => ({
         name: maincategory.name,

--- a/src/components/tags/TagCategory/CategoryContent.tsx
+++ b/src/components/tags/TagCategory/CategoryContent.tsx
@@ -6,10 +6,9 @@ import { PATH } from "@/application/util";
 import { Icon } from "@/components/common/Icon";
 import { Photo } from "@/components/common/Photo";
 
+import { CategoryTitle } from "./CategoryTitle";
 import { FavoriteCategory } from "./FavoriteCategory";
 import { SlotCategory } from "./SlotCategory";
-
-const FAVORITE_ID = "북마크";
 
 export const CategoryContent = () => {
   const router = useRouter();
@@ -30,19 +29,12 @@ export const CategoryContent = () => {
     },
   });
 
-  const onClickItem = (tagId: number) => {
-    router.push(PATH.getExploreByTagPath(tagId));
-  };
-
   return (
-    <Root collapsible className="w-full min-w-300" defaultValue={FAVORITE_ID} type="single">
+    <Root collapsible className="w-full min-w-300" defaultValue="북마크" type="single">
       <FavoriteCategory />
       {data?.map((item) => (
         <>
-          {item.name === "사용자" && (
-            <div className="py-8 text-18-bold-140">이럴 때 이런 밈은 어때요?</div>
-          )}
-          {item.name === "콘텐츠" && <div className="py-8 text-18-bold-140">밈 바로 찾기</div>}
+          <CategoryTitle title={item.name} />
           <Item key={item.id} value={item.id}>
             <Header className="py-4">
               <Trigger className="flex w-full items-center justify-between gap-8 rounded-full px-4 py-12 text-16-semibold-140 [&>span>#chevronDown]:data-[state=open]:rotate-180">
@@ -73,7 +65,7 @@ export const CategoryContent = () => {
                       <li className="flex w-full justify-between gap-6 pl-20" key={tag.tagId}>
                         <button
                           className="w-full rounded-8 py-8 pl-16 hover:bg-primary-200"
-                          onClick={() => onClickItem(tag.tagId)}
+                          onClick={() => router.push(PATH.getExploreByTagPath(tag.tagId))}
                         >
                           <div className="grow text-left">{tag.name}</div>
                         </button>

--- a/src/components/tags/TagCategory/CategoryTitle.tsx
+++ b/src/components/tags/TagCategory/CategoryTitle.tsx
@@ -1,0 +1,15 @@
+const titles = {
+  북마크: "당신이 즐겨찾는 태그",
+  사용자: "이럴 때 이런 밈은 어때요?",
+  콘텐츠: "밈 바로 찾기",
+};
+
+interface Props {
+  title: string;
+}
+
+export const CategoryTitle = ({ title }: Props) => {
+  if (!(title in titles)) return null;
+
+  return <div className="py-8 text-18-bold-140">{titles[title as keyof typeof titles]}</div>;
+};

--- a/src/components/tags/TagCategory/FavoriteCategory.tsx
+++ b/src/components/tags/TagCategory/FavoriteCategory.tsx
@@ -8,20 +8,13 @@ import { Photo } from "@/components/common/Photo";
 
 const FAVORITE_ID = "북마크";
 const TAG_DELETE_DELAY = 1500;
+const FAVORITE_ICON = "/icon/star.svg";
 
 export const FavoriteCategory = () => {
   const { isLogin } = useAuth();
   const router = useRouter();
   const { show, close } = useToast();
-  const { favoriteCategory } = useGetFavoriteTags({ enabled: isLogin });
-
-  const favoriteItem = {
-    name: FAVORITE_ID,
-    id: FAVORITE_ID,
-    icon: "/icon/star.svg",
-    categories: favoriteCategory,
-    mainTags: [],
-  };
+  const { favoriteTags } = useGetFavoriteTags({ enabled: isLogin });
 
   const onClickItem = (tagId: number) => {
     router.push(PATH.getExploreByTagPath(tagId));
@@ -57,14 +50,16 @@ export const FavoriteCategory = () => {
     });
   };
 
+  if (!favoriteTags) return <></>;
+
   return (
     <>
       <div className="py-8 text-18-bold-140">당신이 즐겨찾는 태그</div>
-      <Item value={favoriteItem.id}>
+      <Item value={FAVORITE_ID}>
         <Header className="py-4">
           <Trigger className="flex w-full items-center justify-between gap-8 rounded-full px-4 py-12 text-16-semibold-140 [&>span>#chevronDown]:data-[state=open]:rotate-180">
-            <Photo className="h-24 w-24 p-2" loading="eager" src={favoriteItem.icon} />
-            <span className="flex-grow text-left text-16-semibold-140">{favoriteItem.name}</span>
+            <Photo className="h-24 w-24 p-2" loading="eager" src={FAVORITE_ICON} />
+            <span className="flex-grow text-left text-16-semibold-140">{FAVORITE_ID}</span>
             <span className="flex h-40 w-40 items-center justify-center rounded-full hover:bg-gray-100">
               <Icon
                 aria-hidden
@@ -77,24 +72,22 @@ export const FavoriteCategory = () => {
         </Header>
         <Content className="overflow-hidden data-[state=open]:animate-slide-down data-[state=closed]:animate-slide-up">
           <ul className="flex flex-col pr-16 font-suit text-16-semibold-140">
-            {favoriteItem.categories.map((category) => (
+            {favoriteTags.map((tag) => (
               <>
-                {category.tags.map((tag) => (
-                  <li className="flex w-full justify-between gap-6 pl-20" key={tag.tagId}>
-                    <button
-                      className="w-full rounded-8 py-8 pl-16 hover:bg-primary-200"
-                      onClick={() => onClickItem(tag.tagId)}
-                    >
-                      <div className="grow text-left">{tag.name}</div>
-                    </button>
-                    <button
-                      className="flex h-40 w-40 items-center justify-center rounded-full hover:bg-gray-100 [&_*]:stroke-gray-600 [&_*]:hover:stroke-black"
-                      onClick={() => handleDeleteItem(tag.tagId)}
-                    >
-                      <Icon height={24} name="cancel" width={24} />
-                    </button>
-                  </li>
-                ))}
+                <li className="flex w-full justify-between gap-6 pl-20" key={tag.tagId}>
+                  <button
+                    className="w-full rounded-8 py-8 pl-16 hover:bg-primary-200"
+                    onClick={() => onClickItem(tag.tagId)}
+                  >
+                    <div className="grow text-left">{tag.name}</div>
+                  </button>
+                  <button
+                    className="flex h-40 w-40 items-center justify-center rounded-full hover:bg-gray-100 [&_*]:stroke-gray-600 [&_*]:hover:stroke-black"
+                    onClick={() => handleDeleteItem(tag.tagId)}
+                  >
+                    <Icon height={24} name="cancel" width={24} />
+                  </button>
+                </li>
               </>
             ))}
           </ul>

--- a/src/components/tags/TagCategory/FavoriteCategory.tsx
+++ b/src/components/tags/TagCategory/FavoriteCategory.tsx
@@ -1,0 +1,105 @@
+import { Content, Header, Item, Trigger } from "@radix-ui/react-accordion";
+import { useRouter } from "next/router";
+
+import { useAuth, useDeleteFavoriteTag, useGetFavoriteTags, useToast } from "@/application/hooks";
+import { PATH } from "@/application/util";
+import { Icon } from "@/components/common/Icon";
+import { Photo } from "@/components/common/Photo";
+
+const FAVORITE_ID = "북마크";
+const TAG_DELETE_DELAY = 1500;
+
+export const FavoriteCategory = () => {
+  const { isLogin } = useAuth();
+  const router = useRouter();
+  const { show, close } = useToast();
+  const { favoriteCategory } = useGetFavoriteTags({ enabled: isLogin });
+
+  const favoriteItem = {
+    name: FAVORITE_ID,
+    id: FAVORITE_ID,
+    icon: "/icon/star.svg",
+    categories: favoriteCategory,
+    mainTags: [],
+  };
+
+  const onClickItem = (tagId: number) => {
+    router.push(PATH.getExploreByTagPath(tagId));
+  };
+
+  const { mutate: deleteFavoriteTag, onCancel } = useDeleteFavoriteTag(TAG_DELETE_DELAY);
+
+  const handleDeleteItem = async (tagId: number) => {
+    show(
+      (id) => (
+        <>
+          <div className="grow">태그가 삭제 되었습니다.</div>
+          <button
+            className="justify-self-end text-14-semibold-140 leading-none text-gray-400"
+            onClick={() => {
+              onCancel();
+              close({ id, duration: 0 });
+              show("태그 삭제를 취소 하였습니다.");
+            }}
+          >
+            삭제 취소
+          </button>
+        </>
+      ),
+      { duration: TAG_DELETE_DELAY },
+    );
+
+    deleteFavoriteTag(tagId, {
+      onError: (err) => {
+        if (err instanceof Error && err.name === "CanceledError") return;
+        show("태그 삭제가 실패하였습니다.");
+      },
+    });
+  };
+
+  return (
+    <>
+      <div className="py-8 text-18-bold-140">당신이 즐겨찾는 태그</div>
+      <Item value={favoriteItem.id}>
+        <Header className="py-4">
+          <Trigger className="flex w-full items-center justify-between gap-8 rounded-full px-4 py-12 text-16-semibold-140 [&>span>#chevronDown]:data-[state=open]:rotate-180">
+            <Photo className="h-24 w-24 p-2" loading="eager" src={favoriteItem.icon} />
+            <span className="flex-grow text-left text-16-semibold-140">{favoriteItem.name}</span>
+            <span className="flex h-40 w-40 items-center justify-center rounded-full hover:bg-gray-100">
+              <Icon
+                aria-hidden
+                className="transition-transform duration-300 ease-[cubic-bezier(0.87,0,0.13,1)]"
+                id="chevronDown"
+                name="chevronDown"
+              />
+            </span>
+          </Trigger>
+        </Header>
+        <Content className="overflow-hidden data-[state=open]:animate-slide-down data-[state=closed]:animate-slide-up">
+          <ul className="flex flex-col pr-16 font-suit text-16-semibold-140">
+            {favoriteItem.categories.map((category) => (
+              <>
+                {category.tags.map((tag) => (
+                  <li className="flex w-full justify-between gap-6 pl-20" key={tag.tagId}>
+                    <button
+                      className="w-full rounded-8 py-8 pl-16 hover:bg-primary-200"
+                      onClick={() => onClickItem(tag.tagId)}
+                    >
+                      <div className="grow text-left">{tag.name}</div>
+                    </button>
+                    <button
+                      className="flex h-40 w-40 items-center justify-center rounded-full hover:bg-gray-100 [&_*]:stroke-gray-600 [&_*]:hover:stroke-black"
+                      onClick={() => handleDeleteItem(tag.tagId)}
+                    >
+                      <Icon height={24} name="cancel" width={24} />
+                    </button>
+                  </li>
+                ))}
+              </>
+            ))}
+          </ul>
+        </Content>
+      </Item>
+    </>
+  );
+};

--- a/src/components/tags/TagCategory/FavoriteCategory.tsx
+++ b/src/components/tags/TagCategory/FavoriteCategory.tsx
@@ -6,6 +6,8 @@ import { PATH } from "@/application/util";
 import { Icon } from "@/components/common/Icon";
 import { Photo } from "@/components/common/Photo";
 
+import { CategoryTitle } from "./CategoryTitle";
+
 const FAVORITE_ID = "북마크";
 const TAG_DELETE_DELAY = 1500;
 const FAVORITE_ICON = "/icon/star.svg";
@@ -15,10 +17,6 @@ export const FavoriteCategory = () => {
   const router = useRouter();
   const { show, close } = useToast();
   const { favoriteTags } = useGetFavoriteTags({ enabled: isLogin });
-
-  const onClickItem = (tagId: number) => {
-    router.push(PATH.getExploreByTagPath(tagId));
-  };
 
   const { mutate: deleteFavoriteTag, onCancel } = useDeleteFavoriteTag(TAG_DELETE_DELAY);
 
@@ -50,11 +48,11 @@ export const FavoriteCategory = () => {
     });
   };
 
-  if (!favoriteTags) return <></>;
+  if (!favoriteTags || !favoriteTags.length) return null;
 
   return (
     <>
-      <div className="py-8 text-18-bold-140">당신이 즐겨찾는 태그</div>
+      <CategoryTitle title={FAVORITE_ID} />
       <Item value={FAVORITE_ID}>
         <Header className="py-4">
           <Trigger className="flex w-full items-center justify-between gap-8 rounded-full px-4 py-12 text-16-semibold-140 [&>span>#chevronDown]:data-[state=open]:rotate-180">
@@ -77,7 +75,7 @@ export const FavoriteCategory = () => {
                 <li className="flex w-full justify-between gap-6 pl-20" key={tag.tagId}>
                   <button
                     className="w-full rounded-8 py-8 pl-16 hover:bg-primary-200"
-                    onClick={() => onClickItem(tag.tagId)}
+                    onClick={() => router.push(PATH.getExploreByTagPath(tag.tagId))}
                   >
                     <div className="grow text-left">{tag.name}</div>
                   </button>

--- a/src/components/tags/TagCategory/SlotCategory.tsx
+++ b/src/components/tags/TagCategory/SlotCategory.tsx
@@ -74,7 +74,7 @@ export const SlotCategory = ({ tags, name }: Props) => {
       </div>
 
       <div className={`flex ${isOpen === "closed" ? "absolute opacity-0" : ""}`}>
-        <span>ooo</span>
+        <span>OOO</span>
         {name === "행위" && <span>할때</span>}
       </div>
       <span>{categoryName[name as keyof typeof categoryName]}</span>

--- a/src/components/tags/TagCategory/SlotCategory.tsx
+++ b/src/components/tags/TagCategory/SlotCategory.tsx
@@ -4,10 +4,16 @@ import { css } from "twin.macro";
 
 import type { Tag } from "@/infra/api/tags/types";
 
-const categoryName = {
+const categoryName: { [key: string]: string } = {
   사용자: "이(가) 찾는 밈",
   감정: "을(를) 느낄 때",
   행위: "",
+};
+
+const categoryOpenName: { [key: string]: string } = {
+  사용자: "OOO이(가) 찾는 밈",
+  감정: "OOO을(를) 느낄 때",
+  행위: "OOO할 때",
 };
 
 const ANIMATION_DURATION = 1000;
@@ -17,12 +23,10 @@ interface Props {
   name: string;
 }
 
-type OpenType = "open" | "closed";
-
 export const SlotCategory = ({ tags, name }: Props) => {
   const animationTags = [...tags, tags[0]];
   const ref = useRef<HTMLDivElement>(null);
-  const [isOpen, setIsOpen] = useState<OpenType>("closed");
+  const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
     const parent = ref.current?.closest("[data-state]") as HTMLElement;
@@ -32,7 +36,7 @@ export const SlotCategory = ({ tags, name }: Props) => {
         if (mutation.attributeName === "data-state") {
           const mutatedParent = mutation.target as HTMLElement;
           const currentState = mutatedParent.dataset.state;
-          setIsOpen(currentState as OpenType);
+          setIsOpen(currentState === "open");
         }
       });
     });
@@ -54,7 +58,7 @@ export const SlotCategory = ({ tags, name }: Props) => {
 
   return (
     <div className="flex" ref={ref}>
-      <div className={`flex ${isOpen === "open" ? "absolute opacity-0" : ""}`}>
+      <div className={`flex ${isOpen ? "absolute opacity-0" : ""}`}>
         <div className="h-22 w-fit overflow-hidden text-16-semibold-140">
           <span
             css={css`
@@ -73,11 +77,7 @@ export const SlotCategory = ({ tags, name }: Props) => {
         </div>
       </div>
 
-      <div className={`flex ${isOpen === "closed" ? "absolute opacity-0" : ""}`}>
-        <span>OOO</span>
-        {name === "행위" && <span>할때</span>}
-      </div>
-      <span>{categoryName[name as keyof typeof categoryName]}</span>
+      {isOpen ? categoryOpenName[name] : categoryName[name]}
     </div>
   );
 };

--- a/src/components/tags/TagCategory/SlotCategory.tsx
+++ b/src/components/tags/TagCategory/SlotCategory.tsx
@@ -5,15 +5,9 @@ import { css } from "twin.macro";
 import type { Tag } from "@/infra/api/tags/types";
 
 const categoryName: { [key: string]: string } = {
-  사용자: "이(가) 찾는 밈",
-  감정: "을(를) 느낄 때",
-  행위: "",
-};
-
-const categoryOpenName: { [key: string]: string } = {
-  사용자: "OOO이(가) 찾는 밈",
-  감정: "OOO을(를) 느낄 때",
-  행위: "OOO할 때",
+  "OOO이 찾는 밈": "이(가) 찾는 밈",
+  "OOO을 느낄 때": "을(를) 느낄 때",
+  "OOO할 때": "",
 };
 
 const ANIMATION_DURATION = 1000;
@@ -77,7 +71,7 @@ export const SlotCategory = ({ tags, name }: Props) => {
         </div>
       </div>
 
-      {isOpen ? categoryOpenName[name] : categoryName[name]}
+      {isOpen ? name : categoryName[name]}
     </div>
   );
 };

--- a/src/infra/api/tags/index.ts
+++ b/src/infra/api/tags/index.ts
@@ -44,7 +44,7 @@ export class TagApi {
 
   getCategoryWithTags = () => {
     return this.api
-      .get<GetCategoryByTagResponse>("/tags/categories")
+      .get<GetCategoryByTagResponse>("/tags/categories/new")
       .then((response) => response.data);
   };
 


### PR DESCRIPTION
## 📮 관련 이슈
- resolved: #15 #20 

## ⛳️ 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

## 🌱 PR 포인트
**즐겨찾기 UI 분리 (`FavoriteCategory` 로 분리)**
- 즐겨찾기 관련 로직들도 `FavoriteCategory` 로 분리
- 즐겨찾기한 태그가 없는 경우 `return null;` 

**즐겨찾기 api 응답값 그대로 가져오는 것으로 변경**
```ts
AS-IS //기존에는 태그 카테고리 api 에 맞게 가공해서 return
const useFavoriteTags = ()  => {
...
const favoriteCategory = [
    {
      categoryId: 0,
      name: "",
      priority: 0,
      tags: data?.tags || [],
    },
  ];

  return { favoriteCategory: favoriteCategory, favoriteTags: data?.tags };
}
```
```ts
TO-BE //태그 응답값 바로  return
const useFavoriteTags = ()  => {
....
  return { favoriteTags: data?.tags };
}
```
**태그 카테고리 안의 비즈니스 문구들 `CategoryTitle` 로 분리**
```ts
AS-IS //기존에는 `CategoryContent` 안에서 item.id 를 통해 처리
{item.id === "1" && (<div className="py-8 text-18-bold-140">이럴 때 이런 밈은 어때요?</div> )}
{item.id === "4" && <div className="py-8 text-18-bold-140">밈 바로 찾기</div>}
```
```ts
TO-BE // titles 객체를 만들고 key 값으로 가져오게 처리
export const CategoryTitle = ({ title }: Props) => {
  if (!(title in titles)) return null;

  return <div className="py-8 text-18-bold-140">{titles[title as keyof typeof titles]}</div>;
};
```

## 📸 스크린샷
|스크린샷|스크린샷|
|:--:|:--:|
|파일첨부바람|파일첨부바람|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->