### PR TITLE
💄 Style: 검색 창, 검색 페이지 디자인 반영

### DIFF
--- a/mocks/handlers/search/index.ts
+++ b/mocks/handlers/search/index.ts
@@ -4,24 +4,6 @@ import type { GetMemesResponse } from "@/types";
 
 import * as MOCK_DATA from "./data";
 
-export const getSearch = rest.get(
-  `${process.env.NEXT_PUBLIC_API_URL}/tags/search`,
-  (req, res, ctx) => {
-    const query = req.url.searchParams.get("word");
-
-    if (!query) {
-      return res(ctx.delay(), ctx.status(404));
-    }
-
-    return res(
-      ctx.delay(),
-      ctx.json({
-        tags: MOCK_DATA.tags.filter((tag) => tag.name.search(query) !== -1),
-      }),
-    );
-  },
-);
-
 export const getSearchResultsByKeyword = rest.get(
   `${process.env.NEXT_PUBLIC_SEARCH_API_URL}/search`,
   (req, res, ctx) => {

--- a/mocks/handlers/tags/index.ts
+++ b/mocks/handlers/tags/index.ts
@@ -67,6 +67,19 @@ export const deleteFavoriteTag = rest.delete(
   },
 );
 
+export const getTagAutoSearch = rest.get(
+  `${process.env.NEXT_PUBLIC_API_URL}/tags/search`,
+  async (req, res, ctx) => {
+    return res(
+      ctx.delay(),
+      ctx.status(200),
+      ctx.json({
+        tags: MOCK_DATA.favoriteTags,
+      }),
+    );
+  },
+);
+
 /**
  * 태그 상세 조회 API
  */

--- a/src/application/hooks/api/tags/index.ts
+++ b/src/application/hooks/api/tags/index.ts
@@ -22,7 +22,7 @@ export const useGetPopularTags = () => {
     queryFn: () => api.tags.getPopularTags(),
   });
 
-  return { tags: data?.tags, ...rest };
+  return { tags: data?.tags.slice(0, 10), ...rest };
 };
 
 /**
@@ -84,7 +84,7 @@ export const fetchTagInfo = (tagId: number, queryClient: QueryClient) =>
 export const useGetFavoriteTags = (
   options: Pick<UseQueryOptions, "enabled"> = { enabled: false },
 ) => {
-  const { data, ...rest } = useQuery<GetFavoriteTagsResponse>({
+  const { data } = useQuery<GetFavoriteTagsResponse>({
     queryKey: QUERY_KEYS.getFavoriteTags,
     queryFn: () => api.tags.getFavoriteTags(),
     ...options,

--- a/src/application/hooks/common/useColoredText.tsx
+++ b/src/application/hooks/common/useColoredText.tsx
@@ -17,13 +17,13 @@ export const useColoredText = ({ tagName, searchText }: Props) => {
   const ColoredText: ReactNode = (
     <>
       {checkValidation && index !== -1 ? (
-        <div className="truncate">
+        <>
           <span>{tagName.slice(0, tagName.search(searchText))}</span>
           <span className="text-secondary-1000">
             {tagName.slice(index, index + searchText.length)}
           </span>
           <span>{tagName.slice(index + searchText.length)}</span>
-        </div>
+        </>
       ) : (
         <span>{tagName}</span>
       )}

--- a/src/application/hooks/domain/search/useRecentSearch/useRecentSearch.ts
+++ b/src/application/hooks/domain/search/useRecentSearch/useRecentSearch.ts
@@ -37,5 +37,5 @@ export const useRecentSearch = () => {
     setItems((prevItems) => [...prevItems.filter((item) => item.id !== id)]);
   };
 
-  return { items, onAddItem, onDeleteItem };
+  return { items: items.slice(0, 10), onAddItem, onDeleteItem };
 };

--- a/src/components/common/Navigation/ExplorePageNavigation.tsx
+++ b/src/components/common/Navigation/ExplorePageNavigation.tsx
@@ -1,9 +1,7 @@
 import { useRouter } from "next/router";
-import tw from "twin.macro";
 
 import { useScrollDirection } from "@/application/hooks";
 import { Logo } from "@/components/common/Navigation/Logo";
-import { SSRSuspense } from "@/components/common/Suspense";
 import { SearchInput } from "@/components/search";
 import { TagCategory } from "@/components/tags";
 
@@ -32,16 +30,14 @@ export const ExplorePageNavigation = ({ title }: Props) => {
         }`}
       >
         <SearchInput
-          css={tw`placeholder:text-gray-900`}
+          className="placeholder:text-gray-900"
           inputMode="none"
           placeholder={title}
           onClick={() => {
             router.push("/search");
           }}
         />
-        <SSRSuspense>
-          <TagCategory />
-        </SSRSuspense>
+        <TagCategory />
       </section>
     </>
   );

--- a/src/components/common/Navigation/ExplorePageNavigation.tsx
+++ b/src/components/common/Navigation/ExplorePageNavigation.tsx
@@ -1,4 +1,12 @@
-import { BackButton } from "./BackButton";
+import { useRouter } from "next/router";
+import tw from "twin.macro";
+
+import { useScrollDirection } from "@/application/hooks";
+import { Logo } from "@/components/common/Navigation/Logo";
+import { SSRSuspense } from "@/components/common/Suspense";
+import { SearchInput } from "@/components/search";
+import { TagCategory } from "@/components/tags";
+
 import { Navigation } from "./Navigation";
 import { SideBar } from "./SideBar";
 
@@ -6,15 +14,35 @@ interface Props {
   title?: string;
 }
 export const ExplorePageNavigation = ({ title }: Props) => {
+  const router = useRouter();
+  const direction = useScrollDirection();
   return (
-    <Navigation>
-      <Navigation.Left>
-        <BackButton />
-        <div className="max-w-200 truncate font-suit text-18-bold-140">{title}</div>
-      </Navigation.Left>
-      <Navigation.Right>
-        <SideBar />
-      </Navigation.Right>
-    </Navigation>
+    <>
+      <Navigation>
+        <Navigation.Left>
+          <Logo />
+        </Navigation.Left>
+        <Navigation.Right>
+          <SideBar />
+        </Navigation.Right>
+      </Navigation>
+      <section
+        className={`sticky z-10 flex items-center gap-7 bg-white transition-[top] ${
+          direction === "DOWN" ? "top-54" : "top-0"
+        }`}
+      >
+        <SearchInput
+          css={tw`placeholder:text-gray-900`}
+          inputMode="none"
+          placeholder={title}
+          onClick={() => {
+            router.push("/search");
+          }}
+        />
+        <SSRSuspense>
+          <TagCategory />
+        </SSRSuspense>
+      </section>
+    </>
   );
 };

--- a/src/components/common/Navigation/ExplorePageNavigation.tsx
+++ b/src/components/common/Navigation/ExplorePageNavigation.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from "next/router";
+import tw from "twin.macro";
 
 import { useScrollDirection } from "@/application/hooks";
 import { Logo } from "@/components/common/Navigation/Logo";
@@ -30,7 +31,7 @@ export const ExplorePageNavigation = ({ title }: Props) => {
         }`}
       >
         <SearchInput
-          className="placeholder:text-gray-900"
+          css={tw`placeholder:text-gray-900`}
           inputMode="none"
           placeholder={title}
           onClick={() => {

--- a/src/components/common/Navigation/IntroPageNavigation.tsx
+++ b/src/components/common/Navigation/IntroPageNavigation.tsx
@@ -1,16 +1,44 @@
+import { useRouter } from "next/router";
+
+import { useScrollDirection } from "@/application/hooks";
+import { SSRSuspense } from "@/components/common/Suspense";
+import { SearchInput } from "@/components/search";
+import { TagCategory } from "@/components/tags";
+
 import { Logo } from "./Logo";
 import { Navigation } from "./Navigation";
 import { SideBar } from "./SideBar";
 
 export const IntroPageNavigation = () => {
+  const router = useRouter();
+  const direction = useScrollDirection();
+
   return (
-    <Navigation>
-      <Navigation.Left>
-        <Logo />
-      </Navigation.Left>
-      <Navigation.Right>
-        <SideBar />
-      </Navigation.Right>
-    </Navigation>
+    <>
+      <Navigation>
+        <Navigation.Left>
+          <Logo />
+        </Navigation.Left>
+        <Navigation.Right>
+          <SideBar />
+        </Navigation.Right>
+      </Navigation>
+      <section
+        className={`sticky z-10 flex items-center gap-7 bg-white transition-[top] ${
+          direction === "DOWN" ? "top-54" : "top-0"
+        }`}
+      >
+        <SearchInput
+          inputMode="none"
+          placeholder="당신이 생각한 '그 밈' 검색하기"
+          onClick={() => {
+            router.push("/search");
+          }}
+        />
+        <SSRSuspense>
+          <TagCategory />
+        </SSRSuspense>
+      </section>
+    </>
   );
 };

--- a/src/components/common/Navigation/IntroPageNavigation.tsx
+++ b/src/components/common/Navigation/IntroPageNavigation.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from "next/router";
 
 import { useScrollDirection } from "@/application/hooks";
-import { SSRSuspense } from "@/components/common/Suspense";
 import { SearchInput } from "@/components/search";
 import { TagCategory } from "@/components/tags";
 
@@ -35,9 +34,7 @@ export const IntroPageNavigation = () => {
             router.push("/search");
           }}
         />
-        <SSRSuspense>
-          <TagCategory />
-        </SSRSuspense>
+        <TagCategory />
       </section>
     </>
   );

--- a/src/components/common/Navigation/MemeDetailPageNavigation.tsx
+++ b/src/components/common/Navigation/MemeDetailPageNavigation.tsx
@@ -1,0 +1,22 @@
+import { BackButton } from "./BackButton";
+import { Navigation } from "./Navigation";
+import { SideBar } from "./SideBar";
+
+/**
+ * @desc
+ * 추후 ExplorePageNavigation 으로 합쳐질 수 있음
+ * 현재 디자인 작업 중인 것 같아서 따로 분리 함
+ *
+ */
+export const MemeDetailPageNavigation = () => {
+  return (
+    <Navigation>
+      <Navigation.Left>
+        <BackButton />
+      </Navigation.Left>
+      <Navigation.Right>
+        <SideBar />
+      </Navigation.Right>
+    </Navigation>
+  );
+};

--- a/src/components/common/Navigation/SearchPageNavigation.tsx
+++ b/src/components/common/Navigation/SearchPageNavigation.tsx
@@ -1,11 +1,14 @@
+import { Logo } from "@/components/common/Navigation/Logo";
+
 import { CloseButton } from "./CloseButton";
 import { Navigation } from "./Navigation";
 
 export const SearchPageNavigation = () => {
   return (
     <Navigation>
-      <Navigation.Left></Navigation.Left>
-      <Navigation.Center>밈 찾기</Navigation.Center>
+      <Navigation.Left>
+        <Logo />
+      </Navigation.Left>
       <Navigation.Right>
         <CloseButton />
       </Navigation.Right>

--- a/src/components/common/Navigation/index.ts
+++ b/src/components/common/Navigation/index.ts
@@ -1,6 +1,7 @@
 export * from "./BackButtonNavigation";
 export * from "./ExplorePageNavigation";
 export * from "./IntroPageNavigation";
+export * from "./MemeDetailPageNavigation";
 export * from "./MyPageNavigation";
 export * from "./Navigation";
 export * from "./SearchPageNavigation";

--- a/src/components/common/PullToRefresh/PullToRefresh.tsx
+++ b/src/components/common/PullToRefresh/PullToRefresh.tsx
@@ -135,10 +135,9 @@ export const PullToRefresh = ({
     <div className="overscroll-y-contain" ref={elementRef}>
       <div
         css={css`
-          padding-top: 0.8rem;
           height: ${headHeight}px;
           position: absolute;
-          top: 5.4rem;
+          top: 14.2rem;
           inset-inline: 0;
         `}
       >

--- a/src/components/common/PullToRefresh/RefreshContent.tsx
+++ b/src/components/common/PullToRefresh/RefreshContent.tsx
@@ -20,5 +20,5 @@ export const RefreshContent = () => {
     };
   }, []);
 
-  return <div className="absolute inset-0 m-auto h-80 w-80" ref={logoContainer} />;
+  return <div className="absolute inset-0 m-auto h-80 w-80 -translate-y-8" ref={logoContainer} />;
 };

--- a/src/components/search/SearchInput/SearchInput.tsx
+++ b/src/components/search/SearchInput/SearchInput.tsx
@@ -8,7 +8,7 @@ interface Props extends InputHTMLAttributes<HTMLInputElement> {
   onSearchByKeyWord?: () => void;
 }
 
-export const SearchInput = ({ onReset, onSearchByKeyWord, value, ...rest }: Props) => {
+export const SearchInput = ({ onReset, onSearchByKeyWord, value, className, ...rest }: Props) => {
   return (
     <form
       className="relative my-16 flex w-full items-center justify-start"
@@ -18,7 +18,7 @@ export const SearchInput = ({ onReset, onSearchByKeyWord, value, ...rest }: Prop
       }}
     >
       <InputBase
-        className="relative h-56 w-full rounded-30 bg-gray-100 pl-22 pr-76 font-suit text-16-semibold-140 text-black outline-none placeholder:text-gray-500"
+        className={`relative h-56 w-full rounded-30 bg-gray-100 pl-22 pr-76 font-suit text-16-semibold-140 text-black outline-none placeholder:text-gray-500 ${className}`}
         value={value}
         {...rest}
         endComponents={

--- a/src/components/search/SearchInput/SearchInput.tsx
+++ b/src/components/search/SearchInput/SearchInput.tsx
@@ -11,22 +11,24 @@ interface Props extends InputHTMLAttributes<HTMLInputElement> {
 export const SearchInput = ({ onReset, onSearchByKeyWord, value, ...rest }: Props) => {
   return (
     <form
-      className="relative flex w-full items-center justify-start py-16"
+      className="relative my-16 flex w-full items-center justify-start"
       onSubmit={(e) => {
         e.preventDefault();
         onSearchByKeyWord?.();
       }}
     >
       <InputBase
-        className="h-56 w-full rounded-30 bg-gray-100 pl-22 pr-65 font-suit text-16-semibold-140 text-black outline-none placeholder:text-gray-500"
+        className="relative h-56 w-full rounded-30 bg-gray-100 pl-22 pr-76 font-suit text-16-semibold-140 text-black outline-none placeholder:text-gray-500"
         value={value}
         {...rest}
         endComponents={
           <>
             {value && (
-              <Icon className="absolute right-46 cursor-pointer" name="delete" onClick={onReset} />
+              <button className="absolute right-44 h-full px-4">
+                <Icon name="delete" onClick={onReset} />
+              </button>
             )}
-            <button className="absolute right-16">
+            <button className="absolute right-0 h-full pl-8 pr-16">
               <Icon name="search" stroke="gray-600" />
             </button>
           </>

--- a/src/components/search/SearchItem/SearchItem.tsx
+++ b/src/components/search/SearchItem/SearchItem.tsx
@@ -20,7 +20,7 @@ export const SearchItem = ({
 
   return (
     <div
-      className="flex h-50 w-full cursor-pointer items-center gap-10 pl-11 pr-6 font-suit text-16-semibold-140"
+      className="flex h-50 w-full cursor-pointer items-center gap-10 pl-11 pr-6 font-suit text-16-regular-140"
       {...rest}
     >
       {startComponent}

--- a/src/components/search/SearchItem/SearchItem.tsx
+++ b/src/components/search/SearchItem/SearchItem.tsx
@@ -20,11 +20,11 @@ export const SearchItem = ({
 
   return (
     <div
-      className="flex h-50 w-full cursor-pointer items-center gap-10 pl-11 pr-6 font-suit text-16-regular-140"
+      className="flex h-50 w-full cursor-pointer items-center gap-12 px-14 font-suit text-16-regular-140"
       {...rest}
     >
       {startComponent}
-      <div className="max-w-230">{ColoredText}</div>
+      <div className="grow truncate pr-4">{ColoredText}</div>
       {endComponent}
     </div>
   );

--- a/src/components/search/SearchPopular/SearchPopularItem.tsx
+++ b/src/components/search/SearchPopular/SearchPopularItem.tsx
@@ -1,18 +1,24 @@
+import { Photo } from "@/components/common/Photo";
+
 interface Props {
   name: string;
-  index: number;
+  imageSrc: string;
 }
 
-export const SearchPopularItem = ({ name, index }: Props) => {
+export const SearchPopularItem = ({ name, imageSrc }: Props) => {
   return (
-    <div
-      className="flex h-50 flex-row items-center justify-items-center"
+    <button
+      className="relative overflow-hidden rounded-26 py-16 px-32"
       onContextMenu={(e) => e.preventDefault()}
     >
-      <div className="mr-10 flex h-16 w-16 justify-center rounded-full border border-black bg-black text-white">
-        {index + 1}
-      </div>
-      <div className="font-suit text-16-regular-140">{name}</div>
-    </div>
+      <Photo
+        alt={name}
+        // NOTE: Photo의 기본 className과 충돌나서 css props로 작성
+        css={{ position: "absolute", inset: 0, filter: "brightness(.5)" }}
+        sizes="100px"
+        src={imageSrc}
+      />
+      <span className="relative font-suit text-14-semibold-140 text-white">{name}</span>
+    </button>
   );
 };

--- a/src/components/search/SearchPopular/SearchPopularList.tsx
+++ b/src/components/search/SearchPopular/SearchPopularList.tsx
@@ -9,7 +9,7 @@ export const SearchPopularList = () => {
   const { tags } = useGetPopularTags();
 
   return (
-    <ul className="flex w-screen max-w-[48rem] -translate-x-[1.8rem] gap-8 overflow-x-auto py-12 px-18">
+    <ul className="flex w-screen max-w-[48rem] -translate-x-18 gap-8 overflow-x-auto py-12 px-20">
       {tags?.map((tag) => (
         <li className="shrink-0" key={tag.tagId}>
           <Link href={PATH.getExploreByTagPath(tag.tagId)}>

--- a/src/components/search/SearchPopular/SearchPopularList.tsx
+++ b/src/components/search/SearchPopular/SearchPopularList.tsx
@@ -9,7 +9,7 @@ export const SearchPopularList = () => {
   const { tags } = useGetPopularTags();
 
   return (
-    <ul className="flex gap-8 overflow-x-auto py-12">
+    <ul className="flex w-screen max-w-[48rem] -translate-x-[1.8rem] gap-8 overflow-x-auto py-12 px-18">
       {tags?.map((tag) => (
         <li className="shrink-0" key={tag.tagId}>
           <Link href={PATH.getExploreByTagPath(tag.tagId)}>

--- a/src/components/search/SearchPopular/SearchPopularList.tsx
+++ b/src/components/search/SearchPopular/SearchPopularList.tsx
@@ -9,11 +9,11 @@ export const SearchPopularList = () => {
   const { tags } = useGetPopularTags();
 
   return (
-    <ul className="px-14">
-      {tags?.map((tag, index) => (
-        <li key={tag.tagId}>
+    <ul className="flex gap-8 overflow-x-auto py-12">
+      {tags?.map((tag) => (
+        <li className="shrink-0" key={tag.tagId}>
           <Link href={PATH.getExploreByTagPath(tag.tagId)}>
-            <SearchPopularItem index={index} name={tag.name} />
+            <SearchPopularItem imageSrc="" name={tag.name} />
           </Link>
         </li>
       ))}

--- a/src/components/search/SearchRecent/SearchRecent.tsx
+++ b/src/components/search/SearchRecent/SearchRecent.tsx
@@ -28,6 +28,7 @@ export const SearchRecent = ({ items, onAddItem, onDelete }: Props) => {
             endComponent={
               <Icon
                 className="shrink-0"
+                color="gray-600"
                 name="delete2"
                 onClick={(e) => {
                   e.stopPropagation();
@@ -36,7 +37,7 @@ export const SearchRecent = ({ items, onAddItem, onDelete }: Props) => {
               />
             }
             startComponent={
-              <Icon className="shrink-0" name={isTagType(type) ? "pound" : "search"} />
+              <Icon className="min-w-24 shrink-0" name={isTagType(type) ? "pound" : "search"} />
             }
             onClick={() => {
               onAddItem({ value, type, id });

--- a/src/components/search/SearchRecent/SearchRecent.tsx
+++ b/src/components/search/SearchRecent/SearchRecent.tsx
@@ -27,7 +27,7 @@ export const SearchRecent = ({ items, onAddItem, onDelete }: Props) => {
             tagName={value}
             endComponent={
               <Icon
-                className="shrink-0"
+                className="min-w-24"
                 color="gray-600"
                 name="delete2"
                 onClick={(e) => {
@@ -37,7 +37,7 @@ export const SearchRecent = ({ items, onAddItem, onDelete }: Props) => {
               />
             }
             startComponent={
-              <Icon className="min-w-24 shrink-0" name={isTagType(type) ? "pound" : "search"} />
+              <Icon className="min-w-24" name={isTagType(type) ? "pound" : "search"} />
             }
             onClick={() => {
               onAddItem({ value, type, id });

--- a/src/components/search/SearchRecent/SearchRecent.tsx
+++ b/src/components/search/SearchRecent/SearchRecent.tsx
@@ -27,7 +27,7 @@ export const SearchRecent = ({ items, onAddItem, onDelete }: Props) => {
             tagName={value}
             endComponent={
               <Icon
-                className="absolute right-6"
+                className="shrink-0"
                 name="delete2"
                 onClick={(e) => {
                   e.stopPropagation();
@@ -36,7 +36,7 @@ export const SearchRecent = ({ items, onAddItem, onDelete }: Props) => {
               />
             }
             startComponent={
-              <Icon className="min-w-24" name={isTagType(type) ? "pound" : "search"} />
+              <Icon className="shrink-0" name={isTagType(type) ? "pound" : "search"} />
             }
             onClick={() => {
               onAddItem({ value, type, id });

--- a/src/components/search/Skeleton/SkeletonTagList.tsx
+++ b/src/components/search/Skeleton/SkeletonTagList.tsx
@@ -4,7 +4,12 @@ export const SkeletonTagList = () => {
   return (
     <div className="flex gap-8 overflow-x-auto py-12">
       {Array.from(Array(3).keys()).map((i) => (
-        <Skeleton as="div" key={i} style={{ width: "8rem", height: "5.2rem" }} variant="rounded" />
+        <Skeleton
+          as="div"
+          key={i}
+          style={{ width: "8rem", height: "5.2rem", borderRadius: "2.6rem" }}
+          variant="rounded"
+        />
       ))}
     </div>
   );

--- a/src/components/search/Skeleton/SkeletonTagList.tsx
+++ b/src/components/search/Skeleton/SkeletonTagList.tsx
@@ -2,9 +2,9 @@ import { Skeleton } from "@/components/common/Skeleton";
 
 export const SkeletonTagList = () => {
   return (
-    <div className="flex flex-col gap-10 px-14">
-      {Array.from(Array(5).keys()).map((i) => (
-        <Skeleton as="div" key={i} style={{ width: "100%", height: "5rem" }} variant="rounded" />
+    <div className="flex gap-8 overflow-x-auto py-12">
+      {Array.from(Array(3).keys()).map((i) => (
+        <Skeleton as="div" key={i} style={{ width: "8rem", height: "5.2rem" }} variant="rounded" />
       ))}
     </div>
   );

--- a/src/components/tags/TagCategory/TagCategory.tsx
+++ b/src/components/tags/TagCategory/TagCategory.tsx
@@ -31,7 +31,7 @@ export const TagCategory = () => {
           </div>
         )}
       </Drawer.Trigger>
-      <Drawer.Content direction="top" top="14.4rem">
+      <Drawer.Content direction="top" top="14.2rem">
         <SSRSuspense>
           <CategoryContent />
         </SSRSuspense>

--- a/src/components/tags/TagCategory/TagCategory.tsx
+++ b/src/components/tags/TagCategory/TagCategory.tsx
@@ -15,7 +15,7 @@ export const TagCategory = () => {
     <Drawer isOpen={isOpen} onOpenChange={handleChange}>
       <Drawer.Trigger>
         {({ isOpen }) => (
-          <div className="pt-8">
+          <div>
             <span className="text-18-bold-140 text-primary-500">Tag</span>
             <span
               css={css`

--- a/src/pages/explore/keywords/index.tsx
+++ b/src/pages/explore/keywords/index.tsx
@@ -16,7 +16,6 @@ const ExploreByKeywordPage: NextPage<Props> = ({ searchQuery }) => {
   return (
     <>
       <NextSeo description={DEFAULT_DESCRIPTION} title={TITLE.exploreByKeyword(searchQuery)} />
-
       <ExplorePageNavigation title={searchQuery} />
       <PullToRefresh>
         <div className="mt-12">

--- a/src/pages/explore/keywords/index.tsx
+++ b/src/pages/explore/keywords/index.tsx
@@ -18,11 +18,9 @@ const ExploreByKeywordPage: NextPage<Props> = ({ searchQuery }) => {
       <NextSeo description={DEFAULT_DESCRIPTION} title={TITLE.exploreByKeyword(searchQuery)} />
       <ExplorePageNavigation title={searchQuery} />
       <PullToRefresh>
-        <div className="mt-12">
-          <SSRSuspense fallback={<MemeListSkeleton />}>
-            <MemesByKeyword searchQuery={searchQuery} />
-          </SSRSuspense>
-        </div>
+        <SSRSuspense fallback={<MemeListSkeleton />}>
+          <MemesByKeyword searchQuery={searchQuery} />
+        </SSRSuspense>
       </PullToRefresh>
     </>
   );

--- a/src/pages/explore/tags/[tagId].tsx
+++ b/src/pages/explore/tags/[tagId].tsx
@@ -22,9 +22,7 @@ const ExploreByTagPage: NextPage<Props> = ({ searchQuery, tagId }) => {
       <ExplorePageNavigation title={`#${searchQuery}`} />
 
       <PullToRefresh>
-        <div className="mt-12">
-          <MemesByTag searchQuery={searchQuery} />
-        </div>
+        <MemesByTag searchQuery={searchQuery} />
       </PullToRefresh>
       <TagBookmarkButton tagId={tagId} />
     </>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,20 +1,12 @@
 import type { NextPage } from "next";
-import { useRouter } from "next/router";
 
-import { useScrollDirection } from "@/application/hooks";
 import { DEFAULT_DESCRIPTION, TITLE } from "@/application/util";
 import { IntroPageNavigation } from "@/components/common/Navigation";
 import { NextSeo } from "@/components/common/NextSeo";
 import { PullToRefresh } from "@/components/common/PullToRefresh";
-import { SSRSuspense } from "@/components/common/Suspense";
 import { MemeListContainer } from "@/components/home";
-import { SearchInput } from "@/components/search";
-import { TagCategory } from "@/components/tags";
 
 const HomePage: NextPage = () => {
-  const router = useRouter();
-  const direction = useScrollDirection();
-
   return (
     <>
       <NextSeo
@@ -25,22 +17,6 @@ const HomePage: NextPage = () => {
       <IntroPageNavigation />
 
       <PullToRefresh>
-        <section
-          className={`sticky z-10 flex gap-7 bg-white transition-[top] ${
-            direction === "DOWN" ? "top-54" : "top-0"
-          }`}
-        >
-          <SearchInput
-            inputMode="none"
-            placeholder="당신이 생각한 '그 밈' 검색하기"
-            onClick={() => {
-              router.push("/search");
-            }}
-          />
-          <SSRSuspense>
-            <TagCategory />
-          </SSRSuspense>
-        </section>
         <MemeListContainer />
       </PullToRefresh>
     </>

--- a/src/pages/memes/[id].tsx
+++ b/src/pages/memes/[id].tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 
 import { fetchMemeDetailById, fetchMemeTagsById } from "@/application/hooks";
 import { TITLE } from "@/application/util";
-import { ExplorePageNavigation } from "@/components/common/Navigation";
+import { MemeDetailPageNavigation } from "@/components/common/Navigation";
 import { NextSeo } from "@/components/common/NextSeo";
 import { MemeListSkeleton, Skeleton } from "@/components/common/Skeleton";
 import { SSRSuspense } from "@/components/common/Suspense";
@@ -26,7 +26,7 @@ interface Props {
 const MemeDetailPage: NextPage<Props> = ({ id, meme: { name, description, image } }) => {
   return (
     <>
-      <ExplorePageNavigation />
+      <MemeDetailPageNavigation />
       <NextSeo
         description={description}
         title={TITLE.memeDetail(name)}

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -46,6 +46,8 @@ const SearchPage: NextPage = () => {
       <SearchPageNavigation />
       <SearchInput
         {...inputProps}
+        // eslint-disable-next-line jsx-a11y/no-autofocus
+        autoFocus
         placeholder="당신이 생각한 '그 밈' 검색하기"
         spellCheck={false}
         type="text"

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -44,37 +44,35 @@ const SearchPage: NextPage = () => {
       />
 
       <SearchPageNavigation />
-      <div className="relative">
-        <SearchInput
-          {...inputProps}
-          placeholder="당신이 생각한 '그 밈' 검색하기"
-          spellCheck={false}
-          type="text"
-          onSearchByKeyWord={onSearchByKeyword}
-        />
-        {inputProps.value && (
-          <>
-            <p className="mb-4 text-16-semibold-140 text-gray-500">태그 자동완성</p>
-            <Suspense>
-              <SearchResultList value={debouncedValue} onAddItem={onAddItem} />
-            </Suspense>
-          </>
-        )}
-        {!inputProps.value && (
-          <>
-            <p className="text-16-semibold-140 text-gray-500">친구들이 찾는 인기태그</p>
-            <SSRSuspense fallback={<SkeletonTagList />}>
-              <SearchPopularList />
-            </SSRSuspense>
-          </>
-        )}
-        {!inputProps.value && (
-          <>
-            <p className="mt-12 mb-4 text-16-semibold-140 text-gray-500">최근 검색</p>
-            <SearchRecent items={items} onAddItem={onAddItem} onDelete={onDeleteItem} />
-          </>
-        )}
-      </div>
+      <SearchInput
+        {...inputProps}
+        placeholder="당신이 생각한 '그 밈' 검색하기"
+        spellCheck={false}
+        type="text"
+        onSearchByKeyWord={onSearchByKeyword}
+      />
+      {inputProps.value && (
+        <>
+          <p className="mb-4 text-16-semibold-140 text-gray-500">태그 자동완성</p>
+          <Suspense>
+            <SearchResultList value={debouncedValue} onAddItem={onAddItem} />
+          </Suspense>
+        </>
+      )}
+      {!inputProps.value && (
+        <>
+          <p className="text-16-semibold-140 text-gray-500">친구들이 찾는 인기태그</p>
+          <SSRSuspense fallback={<SkeletonTagList />}>
+            <SearchPopularList />
+          </SSRSuspense>
+        </>
+      )}
+      {!inputProps.value && (
+        <>
+          <p className="mt-12 mb-4 text-16-semibold-140 text-gray-500">최근 검색</p>
+          <SearchRecent items={items} onAddItem={onAddItem} onDelete={onDeleteItem} />
+        </>
+      )}
     </>
   );
 };

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from "next";
 import { useRouter } from "next/router";
-import { Suspense, useState } from "react";
+import { Suspense } from "react";
 
 import { useDebounce, useInput, useRecentSearch } from "@/application/hooks";
 import { DEFAULT_DESCRIPTION, PATH, TITLE } from "@/application/util";
@@ -26,7 +26,6 @@ const SearchPage: NextPage = () => {
   const inputProps = useInput();
   const { items, onDeleteItem, onAddItem } = useRecentSearch();
   const router = useRouter();
-  const [focus, setFocus] = useState(false);
 
   const onSearchByKeyword = () => {
     if (!inputProps.value || !inputProps.value.trim()) return;
@@ -52,26 +51,28 @@ const SearchPage: NextPage = () => {
           spellCheck={false}
           type="text"
           onSearchByKeyWord={onSearchByKeyword}
-          onBlur={() => {
-            setFocus(false);
-          }}
-          onFocus={() => {
-            setFocus(true);
-          }}
         />
-        <p className="mb-24 px-14 text-12-regular-160 text-gray-500">밈 제목,태그를 입력하세요</p>
         {inputProps.value && (
-          <Suspense>
-            <SearchResultList value={debouncedValue} onAddItem={onAddItem} />
-          </Suspense>
+          <>
+            <p className="mb-4 text-16-semibold-140 text-gray-500">태그 자동완성</p>
+            <Suspense>
+              <SearchResultList value={debouncedValue} onAddItem={onAddItem} />
+            </Suspense>
+          </>
         )}
-        {!inputProps.value && focus && (
-          <SearchRecent items={items} onAddItem={onAddItem} onDelete={onDeleteItem} />
+        {!inputProps.value && (
+          <>
+            <p className="text-16-semibold-140 text-gray-500">친구들이 찾는 인기태그</p>
+            <SSRSuspense fallback={<SkeletonTagList />}>
+              <SearchPopularList />
+            </SSRSuspense>
+          </>
         )}
-        {!inputProps.value && !focus && (
-          <SSRSuspense fallback={<SkeletonTagList />}>
-            <SearchPopularList />
-          </SSRSuspense>
+        {!inputProps.value && (
+          <>
+            <p className="mt-12 mb-4 text-16-semibold-140 text-gray-500">최근 검색</p>
+            <SearchRecent items={items} onAddItem={onAddItem} onDelete={onDeleteItem} />
+          </>
         )}
       </div>
     </>


### PR DESCRIPTION
## 📮 관련 이슈
- resolved: #이슈번호

## ⛳️ 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->
### `<ExplorePageNavigation />`
```tsx
export const ExplorePageNavigation = ({ title }: Props) => {
  const router = useRouter();
  const direction = useScrollDirection();
  return (
    <>
      <Navigation>
        ...
      </Navigation>
      <section
        className={`sticky z-10 flex items-center gap-7 bg-white transition-[top] ${
          direction === "DOWN" ? "top-54" : "top-0"
        }`}
      >
        <SearchInput ... />
        <TagCategory />
      </section>
    </>
  );
};
```
- 스크롤 따라 검색바 움직이는 로직 Navigation으로 옮겼습니다 (IntroPageNavigation도 동일)
- 밈 상세 페이지 전용 `MemeDetailPageNavigation`을 임시로 만들었습니다
- 추후 애니메이션 적용 때문에 검색바 컴포넌트화는 안했습니다

### 검색창 autoFocus
```tsx
 <SearchInput
        {...inputProps}
        // eslint-disable-next-line jsx-a11y/no-autofocus
        autoFocus
 />
```
- 검색 페이지 진입 시 자동으로 foucs 되는 요구사항입니다
- **auto Focus 속성이 접근성 안좋다고 경고가 뜨는데.. 어떻게할까요?**

### 남은 작업
- 스크롤 시 헤더/뒤로가기 버튼 애니메이션
- 인기 태그 대표 이미지 api 연동
- 성과발표회 이전 로컬스토리지 비우기
- 태그 공유하기 버튼과 대표 이미지


## 🌱 PR 포인트
- 

## 📸 스크린샷
|검색-최근/추천|검색-자동완성|
|:--:|:--:|
|<img width="389" alt="image" src="https://user-images.githubusercontent.com/74011724/236660569-dece85d4-63af-4faf-9510-14fec350bad3.png">|<img width="385" alt="image" src="https://user-images.githubusercontent.com/74011724/236660582-c3054b65-2b4f-4b58-8644-a5406f99ad2d.png">|

|검색-키워드|검색-태그|
|:--:|:--:|
|<img width="387" alt="image" src="https://user-images.githubusercontent.com/74011724/236660627-fff99fb6-7026-418b-abf1-f1c4d3d10f36.png">|<img width="382" alt="image" src="https://user-images.githubusercontent.com/74011724/236660634-a6d39515-7d6f-406b-bbf8-13921a992e08.png">|

|Pull To Refresh|스크린샷|
|:--:|:--:|
|![May-07-2023 15-05-18](https://user-images.githubusercontent.com/74011724/236660708-ef89a17c-bded-47ec-ada1-e872a68b220c.gif) | |
## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->