### PR TITLE
:bug: Fix: 밈 api 무한요청 수정

### DIFF
--- a/src/application/hooks/common/useIntersect.ts
+++ b/src/application/hooks/common/useIntersect.ts
@@ -4,20 +4,23 @@ type IntersectHandler = (entry: IntersectionObserverEntry, observer: Intersectio
 
 export const useIntersect = (onIntersect: IntersectHandler, options?: IntersectionObserverInit) => {
   const [ref, setRef] = useState<Element | null>(null);
-  const callbackRef = useRef(
-    (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) onIntersect(entry, observer);
-      });
-    },
+  const callback = (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) onIntersect(entry, observer);
+    });
+  };
+  const observerRef = useRef(
+    typeof IntersectionObserver === "undefined"
+      ? undefined
+      : new IntersectionObserver(callback, options),
   );
 
   useEffect(() => {
-    if (!ref) return;
-    const observer = new IntersectionObserver(callbackRef.current, options);
+    const observer = observerRef.current;
+    if (!ref || !observer) return;
     observer.observe(ref);
     return () => observer.disconnect();
-  }, [ref, options]);
+  }, [ref]);
 
   return setRef;
 };


### PR DESCRIPTION
## 📮 관련 이슈
- resolved: #이슈번호

## ⛳️ 작업 내용

### `useCoreInfiniteQuery`에서 임시로 처리했던 무한요청 현상을 `useIntersect` 에서 해결했습니다
```tsx
export const useIntersect = (onIntersect: IntersectHandler, options?: IntersectionObserverInit) => {
  const [ref, setRef] = useState<Element | null>(null);
  const callback = (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
    entries.forEach((entry) => {
      if (entry.isIntersecting) onIntersect(entry, observer);
    });
  };
  const observerRef = useRef(
    typeof IntersectionObserver === "undefined"
      ? undefined
      : new IntersectionObserver(callback, options),
  );

  useEffect(() => {
    const observer = observerRef.current;
    if (!ref || !observer) return;
    observer.observe(ref);
    return () => observer.disconnect();
  }, [ref]);

  return setRef;
};
```
- 기존 : api 에러 -> InfiniteMemeList 리렌더링 -> 옵션 객체 참조값 다시 생성 -> 다시 useEffect -> api 무한 요청 후 에러
- 개선 : 옵션 객체 참조값에 영향받지 않도록, `Intersect Observer를 ref로 선언`

## 🌱 PR 포인트
### 특정 해상도(가로 4xx, 세로 8xx)에서 무한요청이 일어납니다(?)
![May-17-2023 16-23-34](https://github.com/thismeme-team/thismeme-web/assets/74011724/2ee5a422-0bd0-48fb-a5b2-034c80be0fa5)

- 스크롤 좀 해주면 멈추긴 하는데.. 이건 왜그런지 모르겠네요😇
- 그래도 일반적인 데탑, 핸드폰 해상도에선 무한요청 안일어납니다!


## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->