### PR TITLE
:sparkles: Feat: 인기태그 대표이미지 api 연동

### DIFF
--- a/src/application/hooks/api/tags/index.ts
+++ b/src/application/hooks/api/tags/index.ts
@@ -17,12 +17,12 @@ import { QUERY_KEYS } from "./queryKey";
  * 인기 태그 조회 API
  */
 export const useGetPopularTags = () => {
-  const { data, ...rest } = useQuery<GetPopularTagsResponse>({
+  const { data } = useQuery<GetPopularTagsResponse>({
     queryKey: QUERY_KEYS.getPopularTags,
     queryFn: () => api.tags.getPopularTags(),
   });
 
-  return { tags: data?.tags.slice(0, 10), ...rest };
+  return { ...data };
 };
 
 /**

--- a/src/components/search/SearchPopular/SearchPopularItem.tsx
+++ b/src/components/search/SearchPopular/SearchPopularItem.tsx
@@ -15,6 +15,7 @@ export const SearchPopularItem = ({ name, imageSrc }: Props) => {
         alt={name}
         // NOTE: Photo의 기본 className과 충돌나서 css props로 작성
         css={{ position: "absolute", inset: 0, filter: "brightness(.5)" }}
+        loading="eager"
         sizes="100px"
         src={imageSrc}
       />

--- a/src/components/search/SearchPopular/SearchPopularList.tsx
+++ b/src/components/search/SearchPopular/SearchPopularList.tsx
@@ -13,7 +13,7 @@ export const SearchPopularList = () => {
       {tags?.map((tag) => (
         <li className="shrink-0" key={tag.tagId}>
           <Link href={PATH.getExploreByTagPath(tag.tagId)}>
-            <SearchPopularItem imageSrc="" name={tag.name} />
+            <SearchPopularItem imageSrc={tag.imageUrl} name={tag.name} />
           </Link>
         </li>
       ))}

--- a/src/infra/api/tags/index.ts
+++ b/src/infra/api/tags/index.ts
@@ -4,6 +4,7 @@ import type {
   GetCategoryByTagResponse,
   GetFavoriteTagsResponse,
   GetMemeTagsByIdResponse,
+  GetPopularTagsResponse,
   GetTagInfoResponse,
 } from "./types";
 
@@ -33,7 +34,7 @@ export class TagApi {
   };
 
   getPopularTags = () => {
-    return this.api.get(`/tags?size=5&sort=viewCount,desc`).then((response) => response.data);
+    return this.api.get<GetPopularTagsResponse>(`/tags/rank/new`).then((response) => response.data);
   };
 
   getMemeTagsById = (id: string) => {

--- a/src/infra/api/tags/types.ts
+++ b/src/infra/api/tags/types.ts
@@ -3,11 +3,14 @@ export interface Tag {
   name: string;
   viewCount: number;
   categoryId: number;
-  isFav?: boolean;
+  isFav: boolean;
+  categoryName: string;
+  imageUrl: string;
 }
 
 export interface GetPopularTagsResponse {
-  tags: Tag[];
+  tags: Omit<Tag, "isFav">[];
+  count: number;
 }
 
 export interface GetTagSearchResponse {
@@ -15,7 +18,7 @@ export interface GetTagSearchResponse {
 }
 
 export interface GetMemeTagsByIdResponse {
-  tags: Tag[];
+  tags: Omit<Tag, "isFav" | "imageUrl">[];
 }
 
 export interface Category {
@@ -37,5 +40,5 @@ export interface GetCategoryByTagResponse {
   mainTags: Pick<Tag, "tagId" | "name">[][];
 }
 
-export type GetTagInfoResponse = Tag & { isFav: boolean };
+export type GetTagInfoResponse = Omit<Tag, "imageUrl">;
 export type GetFavoriteTagsResponse = Pick<Category, "tags">;


### PR DESCRIPTION
## 📮 관련 이슈
- resolved: #이슈번호

## ⛳️ 작업 내용
<img width="419" alt="image" src="https://github.com/thismeme-team/thismeme-web/assets/74011724/2d9d6b9c-21f6-46e3-9fb5-9b7fdb38e51a">

- 이미지 가로 사이즈 `256px`로 요청
- loading eager로 태그 10개 이미지 뷰포트에 들어오지 않아도 모두 요청

### `Tag` DTO
```tsx
export interface Tag {
  tagId: number;
  name: string;
  viewCount: number;
  categoryId: number;
  isFav: boolean;
  categoryName: string;
  imageUrl: string;
}

export interface GetPopularTagsResponse {
  tags: Omit<Tag, "isFav">[];
  count: number;
}
export type GetTagInfoResponse = Omit<Tag, "imageUrl">;

```
- 태그 dto를 생성하고, api 마다 pick omit 하도록 수정했습니다


## 🌱 PR 포인트
-

## 📸 스크린샷
|스크린샷|스크린샷|
|:--:|:--:|
|파일첨부바람|파일첨부바람|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->