### PR TITLE
✨ Feat: 헤더 애니메이션 적용, 스타일 버그 수정

### DIFF
--- a/src/application/hooks/common/useScrollDirection.ts
+++ b/src/application/hooks/common/useScrollDirection.ts
@@ -5,6 +5,7 @@ import { throttle } from "@/application/util";
 const SCROLL_DIRECTION = {
   up: "UP",
   down: "DOWN",
+  init: "INIT",
 } as const;
 type DIRECTION = typeof SCROLL_DIRECTION[keyof typeof SCROLL_DIRECTION];
 
@@ -12,7 +13,7 @@ const OFFSET = 100;
 const DELAY = 200;
 export const useScrollDirection = () => {
   const prevScrollY = useRef(0);
-  const [direction, setDirection] = useState<DIRECTION>(SCROLL_DIRECTION.up);
+  const [direction, setDirection] = useState<DIRECTION>(SCROLL_DIRECTION.init);
   useEffect(() => {
     const handleScroll = throttle(() => {
       const currentScrollY = window.scrollY;

--- a/src/components/common/Navigation/BackButton/BackButton.tsx
+++ b/src/components/common/Navigation/BackButton/BackButton.tsx
@@ -1,16 +1,17 @@
 import { useRouter } from "next/router";
+import type { ComponentProps } from "react";
 
 import { useRouteTracking } from "@/application/hooks";
 import { Icon } from "@/components/common/Icon";
 
-export const BackButton = () => {
+export const BackButton = (props: ComponentProps<"button">) => {
   const router = useRouter();
 
   const { isInitialPage } = useRouteTracking();
   if (isInitialPage) return null;
 
   return (
-    <button onClick={() => router.back()}>
+    <button {...props} onClick={() => router.back()}>
       <Icon name="back" />
     </button>
   );

--- a/src/components/common/Navigation/ExplorePageNavigation.tsx
+++ b/src/components/common/Navigation/ExplorePageNavigation.tsx
@@ -1,7 +1,9 @@
 import { useRouter } from "next/router";
-import tw from "twin.macro";
+import { CSSTransition } from "react-transition-group";
+import tw, { css } from "twin.macro";
 
 import { useScrollDirection } from "@/application/hooks";
+import { BackButton } from "@/components/common/Navigation/BackButton";
 import { Logo } from "@/components/common/Navigation/Logo";
 import { SearchInput } from "@/components/search";
 import { TagCategory } from "@/components/tags";
@@ -9,9 +11,12 @@ import { TagCategory } from "@/components/tags";
 import { Navigation } from "./Navigation";
 import { SideBar } from "./SideBar";
 
+const DELAY = 300;
+
 interface Props {
   title?: string;
 }
+
 export const ExplorePageNavigation = ({ title }: Props) => {
   const router = useRouter();
   const direction = useScrollDirection();
@@ -30,14 +35,31 @@ export const ExplorePageNavigation = ({ title }: Props) => {
           direction === "DOWN" ? "top-54" : "top-0"
         }`}
       >
-        <SearchInput
-          css={tw`placeholder:text-gray-900`}
-          inputMode="none"
-          placeholder={title}
-          onClick={() => {
-            router.push("/search");
-          }}
-        />
+        <div className="flex w-full">
+          <CSSTransition mountOnEnter unmountOnExit in={direction === "UP"} timeout={DELAY}>
+            <BackButton
+              css={css`
+                &.enter-done,
+                &.enter-active {
+                  max-width: 50px;
+                  padding-right: 0.8rem;
+                }
+                transition: max-width ${DELAY}ms ease, padding ${DELAY}ms ease;
+                max-width: 0;
+              `}
+            />
+          </CSSTransition>
+
+          <SearchInput
+            css={tw`placeholder:text-gray-900`}
+            inputMode="none"
+            placeholder={title}
+            onClick={() => {
+              router.push("/search");
+            }}
+          />
+        </div>
+
         <TagCategory />
       </section>
     </>

--- a/src/components/common/Navigation/ExplorePageNavigation.tsx
+++ b/src/components/common/Navigation/ExplorePageNavigation.tsx
@@ -60,7 +60,7 @@ export const ExplorePageNavigation = ({ title }: Props) => {
           />
         </div>
 
-        <TagCategory />
+        <TagCategory topOffset={direction === "UP" ? "8.8rem" : "14.2rem"} />
       </section>
     </>
   );

--- a/src/components/common/Navigation/IntroPageNavigation.tsx
+++ b/src/components/common/Navigation/IntroPageNavigation.tsx
@@ -34,7 +34,7 @@ export const IntroPageNavigation = () => {
             router.push("/search");
           }}
         />
-        <TagCategory topOffset="14.2rem" />
+        <TagCategory topOffset={direction === "UP" ? "8.8rem" : "14.2rem"} />
       </section>
     </>
   );

--- a/src/components/common/Navigation/IntroPageNavigation.tsx
+++ b/src/components/common/Navigation/IntroPageNavigation.tsx
@@ -34,7 +34,7 @@ export const IntroPageNavigation = () => {
             router.push("/search");
           }}
         />
-        <TagCategory />
+        <TagCategory topOffset="14.2rem" />
       </section>
     </>
   );

--- a/src/components/common/Navigation/Logo/Logo.tsx
+++ b/src/components/common/Navigation/Logo/Logo.tsx
@@ -1,8 +1,16 @@
+import { useRouter } from "next/router";
+
 import { Icon } from "@/components/common/Icon";
 
 export const Logo = () => {
+  const router = useRouter();
+  const handleClick = () => {
+    if (router.asPath === "/") location.reload();
+    else router.push("/");
+  };
+
   return (
-    <button onClick={() => location.reload()}>
+    <button onClick={handleClick}>
       <Icon name="logo" />
     </button>
   );

--- a/src/components/tags/TagCategory/TagCategory.tsx
+++ b/src/components/tags/TagCategory/TagCategory.tsx
@@ -7,7 +7,10 @@ import { SSRSuspense } from "@/components/common/Suspense";
 import { CategoryContent } from "./CategoryContent";
 import { useTagCategoryContext } from "./context";
 
-export const TagCategory = () => {
+interface Props {
+  topOffset: string;
+}
+export const TagCategory = ({ topOffset }: Props) => {
   const [isOpen, setIsOpen] = useTagCategoryContext();
   const handleChange = () => setIsOpen((prev) => !prev);
 
@@ -31,7 +34,7 @@ export const TagCategory = () => {
           </div>
         )}
       </Drawer.Trigger>
-      <Drawer.Content direction="top" top="14.2rem">
+      <Drawer.Content direction="top" top={topOffset}>
         <SSRSuspense>
           <CategoryContent />
         </SSRSuspense>


### PR DESCRIPTION
## 📮 관련 이슈
- resolved: #이슈번호

## ⛳️ 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->
1. 로고 버튼 **메인페이지 일때 새로고침, 다른 페이지일땐 메인페이지로 이동**
2. 스크롤 시 헤더/뒤로가기 버튼 애니메이션
3. 스크롤 시 태그 드로어 top 스타일 버그 수정

## 🌱 PR 포인트
- `useScrollDirection`에서 스크롤 안한 처음 상태인 init을 추가했습니다

## 📸 스크린샷
|태그 top offset|애니메이션|
|:--:|:--:|
| ![May-18-2023 01-07-57](https://github.com/thismeme-team/thismeme-web/assets/74011724/8b9e63c4-31e0-4008-b42d-228758d7e116)| ![May-18-2023 01-07-38](https://github.com/thismeme-team/thismeme-web/assets/74011724/7d1deebd-dab5-460d-98a3-99c3d6d97281)|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->