### PR TITLE
fix: remove duplicated key warning message

### DIFF
--- a/src/features/common/components/TagCategory/CategoryContent.tsx
+++ b/src/features/common/components/TagCategory/CategoryContent.tsx
@@ -1,6 +1,6 @@
 import { Content, Header, Item, Root, Trigger } from "@radix-ui/react-accordion";
 import { useRouter } from "next/router";
-import React, { Fragment } from "react";
+import React, { Fragment, useState } from "react";
 
 import { useGetCategoryWithTag } from "@/api/tag";
 import { Icon } from "@/common/components/Icon";
@@ -23,9 +23,10 @@ const gtmTrigger: { [key: string]: string } = {
 
 export const CategoryContent = () => {
   const router = useRouter();
+  const [categoryId, setCategoryId] = useState("북마크");
 
   const [, setIsOpenTagCategory] = useTagCategoryContext();
-  const { data } = useGetCategoryWithTag({
+  const { data: categories } = useGetCategoryWithTag({
     select: ({ mainCategories, mainTags }) => {
       const restItem = mainCategories.map((maincategory) => ({
         name: maincategory.name,
@@ -45,24 +46,34 @@ export const CategoryContent = () => {
   };
 
   return (
-    <Root collapsible className="w-full min-w-300" defaultValue="북마크" type="single">
+    <Root
+      collapsible
+      className="w-full min-w-300"
+      type="single"
+      value={categoryId}
+      onValueChange={(value) => setCategoryId(value)}
+    >
       <FavoriteCategory />
-      {data?.map((item) => (
-        <Fragment key={item.id}>
-          <CategoryTitle title={item.name} />
-          <Item value={item.id}>
+      {categories?.map((category) => (
+        <Fragment key={category.id}>
+          <CategoryTitle title={category.name} />
+          <Item value={category.id}>
             <Header className="py-4">
               <Trigger
                 className={`${
-                  gtmTrigger[item.name]
+                  gtmTrigger[category.name]
                 } flex w-full items-center justify-between gap-8 rounded-full px-4 py-12 text-16-semibold-140 [&>span>#chevronDown]:data-[state=open]:rotate-180`}
               >
-                <Photo className="h-24 w-24 p-2" loading="eager" src={item.icon} />
+                <Photo className="h-24 w-24 p-2" loading="eager" src={category.icon} />
                 <span className="flex-grow text-left text-16-semibold-140">
-                  {item.mainTags.length ? (
-                    <SlotCategory name={item.name} tags={item.mainTags} />
+                  {category.mainTags.length ? (
+                    <SlotCategory
+                      name={category.name}
+                      open={categoryId === category.id}
+                      tags={category.mainTags}
+                    />
                   ) : (
-                    item.name
+                    category.name
                   )}
                 </span>
                 <span className="flex h-40 w-40 items-center justify-center rounded-full hover:bg-gray-100">
@@ -77,7 +88,7 @@ export const CategoryContent = () => {
             </Header>
             <Content className="overflow-hidden data-[state=open]:animate-slide-down data-[state=closed]:animate-slide-up">
               <ul className="flex flex-col pr-16 font-suit text-16-semibold-140">
-                {item.categories.map((category) => (
+                {category.categories.map((category) => (
                   <Fragment key={category.categoryId}>
                     <div className="py-8 pl-4 text-gray-600">{category.name}</div>
                     {category.tags.map((tag) => (

--- a/src/features/common/components/TagCategory/SlotCategory.tsx
+++ b/src/features/common/components/TagCategory/SlotCategory.tsx
@@ -1,5 +1,5 @@
 import { keyframes } from "@emotion/react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo } from "react";
 import { css } from "twin.macro";
 
 import type { Tag } from "@/infra/api/tags/types";
@@ -15,35 +15,16 @@ const ANIMATION_DURATION = 1000;
 interface Props {
   tags: Pick<Tag, "tagId" | "name">[];
   name: string;
+  open: boolean;
 }
 
-export const SlotCategory = ({ tags, name }: Props) => {
-  const animationTags = [...tags, tags[0]];
-  const ref = useRef<HTMLDivElement>(null);
-  const [isOpen, setIsOpen] = useState(false);
-
-  useEffect(() => {
-    const parent = ref.current?.closest("[data-state]") as HTMLElement;
-
-    const observer = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        if (mutation.attributeName === "data-state") {
-          const mutatedParent = mutation.target as HTMLElement;
-          const currentState = mutatedParent.dataset.state;
-          setIsOpen(currentState === "open");
-        }
-      });
-    });
-
-    observer.observe(parent, { attributes: true });
-    return () => observer.disconnect();
-  }, []);
-
+export const SlotCategory = ({ tags, name, open }: Props) => {
+  const animationTags = useMemo(() => [...tags, tags[0]], [tags]);
   const slider = useMemo(() => getSliderStyle(tags.length), [tags]);
 
   return (
-    <div className="flex" ref={ref}>
-      <div className={`flex ${isOpen ? "absolute opacity-0" : ""}`}>
+    <div className="flex">
+      <div className={`flex ${open ? "absolute opacity-0" : ""}`}>
         <div className="h-22 w-fit overflow-hidden text-16-semibold-140">
           <span
             css={css`
@@ -62,7 +43,7 @@ export const SlotCategory = ({ tags, name }: Props) => {
         </div>
       </div>
 
-      {isOpen ? name : categoryName[name]}
+      {open ? name : categoryName[name]}
     </div>
   );
 };

--- a/src/features/common/components/TagCategory/SlotCategory.tsx
+++ b/src/features/common/components/TagCategory/SlotCategory.tsx
@@ -62,8 +62,8 @@ export const SlotCategory = ({ tags, name }: Props) => {
               flex-direction: column;
             `}
           >
-            {animationTags.map((tag) => (
-              <div className="h-22" key={tag.tagId}>
+            {animationTags.map((tag, index) => (
+              <div className="h-22" key={`${tag.tagId}-${index}`}>
                 {tag.name}
               </div>
             ))}

--- a/src/features/common/components/TagCategory/SlotCategory.tsx
+++ b/src/features/common/components/TagCategory/SlotCategory.tsx
@@ -1,5 +1,5 @@
 import { keyframes } from "@emotion/react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { css } from "twin.macro";
 
 import type { Tag } from "@/infra/api/tags/types";
@@ -39,16 +39,7 @@ export const SlotCategory = ({ tags, name }: Props) => {
     return () => observer.disconnect();
   }, []);
 
-  const offset = 100 / tags.length;
-  const rotate = keyframes(
-    tags
-      .map(
-        (tag, idx) =>
-          `${offset * (idx + 0.5)}% {transform: translateY(-${offset * (idx + 1)}%);} 
-          ${offset * (idx + 1)}% {transform: translateY(-${offset * (idx + 1)}%);}`,
-      )
-      .join(""),
-  );
+  const slider = useMemo(() => getSliderStyle(tags.length), [tags]);
 
   return (
     <div className="flex" ref={ref}>
@@ -57,7 +48,7 @@ export const SlotCategory = ({ tags, name }: Props) => {
           <span
             css={css`
               height: ${tags.length * 100}%;
-              animation: ${rotate} ${ANIMATION_DURATION * tags.length}ms linear infinite;
+              animation: ${slider} ${ANIMATION_DURATION * tags.length}ms linear infinite;
               display: flex;
               flex-direction: column;
             `}
@@ -75,3 +66,15 @@ export const SlotCategory = ({ tags, name }: Props) => {
     </div>
   );
 };
+
+function getSliderStyle(length: number) {
+  const offset = 100 / length;
+  return keyframes(
+    Array.from(Array(length))
+      .map(
+        (_, idx) => `${offset * (idx + 0.5)}% {transform: translateY(-${offset * (idx + 1)}%);} 
+          ${offset * (idx + 1)}% {transform: translateY(-${offset * (idx + 1)}%);}`,
+      )
+      .join(""),
+  );
+}


### PR DESCRIPTION
## 📮 관련 이슈
- resolved: #90 

## ⛳️ 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

- [ ] 중복 key 에 대한 warning 메세지 제거
- [ ] `SlotCategory` 컴포넌트 리팩터링

## 🌱 PR 포인트

### warning 메세지 원인
- 상황: `slider` 애니메이션를 구현하기 위해 첫번째 요소를 하나 더 붙임 => `key` 에 `tags.tagId` 를 넣었기 때문에 동일한 `tag` 에 대한 `key` 중복 발생
- 해결: `tagId` 와 배열 `index` 를 섞어서 `key` 로 사용 [d726213](https://github.com/thismeme-team/thismeme-web/pull/91/commits/d7262135bb1a3b8ce552dd0856fd1f83010af312)

### `MutationObserver` 로직 제거
- 상황: `Accordion` 의 open 상태를 radix 에서 `data-state` 로 관리하고 있어서 자식에서 open 상태에 접근할 수 있는 방법이 없었음. 그래서 자식 요소에서 data-state 의 변경(mutation)을 감지(observer)하기 위해 MutationObserver 사용했음 => **단지 open 상태를 확인하기 위해 번잡한 로직이 들어갔다고 판단하여 리팩터링 진행**
- 리팩터링: `Accordion` 을 제어(controlled) 컴포넌트로 만들어 `SlotCategory` 컴포넌트에 `open` 상태를 `props` 로 넘겨주도록 수정 [f51219f](https://github.com/thismeme-team/thismeme-web/pull/91/commits/f51219fb122fcc7e37267231f945f8df55b4ab70)

## 📸 스크린샷
|스크린샷|스크린샷|
|:--:|:--:|
|파일첨부바람|파일첨부바람|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->