### PR TITLE
fix: SEO & 태그 검색 결과 페이지 개선

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,8 @@
 User-Agent: *
-Disallow: /
+Disallow: /collect
+Disallow: /mypage
+Disallow: /oauth2/redirect
+Disallow: /search
+Disallow: /setting
+Disallow: /share
+Disallow: /upload

--- a/src/api/tag/useGetTagInfo.ts
+++ b/src/api/tag/useGetTagInfo.ts
@@ -9,7 +9,7 @@ export const useGetTagInfo = (
   return useSuspendedQuery({
     queryKey: useGetTagInfo.queryKey(tagId),
     queryFn: () => useGetTagInfo.queryFn(tagId),
-    staleTime: 0,
+    staleTime: Infinity,
     ...options,
   });
 };

--- a/src/common/utils/constant.ts
+++ b/src/common/utils/constant.ts
@@ -12,4 +12,6 @@ export const SITE_NAME = "그 밈";
 
 export const DEFAULT_DESCRIPTION = "당신이 찾는 ‘그 밈’ 여기 있다.";
 
+export const canonicalUrl = process.env.NEXT_PUBLIC_CANONICAL_URL;
+
 export const thismemeGuideUrl = "https://zonemy.notion.site/ca4dba6972a340c28e4be60d1cc83547";

--- a/src/common/utils/path.ts
+++ b/src/common/utils/path.ts
@@ -18,7 +18,7 @@ export const PATH = {
   getExploreByTagPath: (tagId: number, tagName?: string) => {
     if (!tagName) return `/explore/tags/${tagId}`;
 
-    const encodedValue = encodeURIComponent(`#${tagName}`);
+    const encodedValue = encodeURIComponent(tagName);
     return `/explore/tags/${tagId}?q=${encodedValue}`;
   },
 

--- a/src/features/explore/tags/components/TagBookmarkButton.tsx
+++ b/src/features/explore/tags/components/TagBookmarkButton.tsx
@@ -14,17 +14,15 @@ const TAG_DELAY = 1500;
 export const TagBookmarkButton = ({ tagId }: Props) => {
   const { show, close } = useToast();
   const { validate, isLoading } = useAuth();
-  const { data, isFetchedAfterMount } = useGetTagInfo(tagId, { enabled: !isLoading });
+  const { data: tagInfo } = useGetTagInfo(tagId, { enabled: !isLoading });
 
   const { mutate: saveMutation } = usePostFavoriteTag();
   const { mutate: deleteMutation, onCancel } = useDeleteFavoriteTag(TAG_DELAY);
   const [, setIsOpenTagCategory] = useTagCategoryContext();
 
-  if (!isFetchedAfterMount || !data) return null;
-  const { isFav } = data;
   const handleSaveBookmark = () => {
     saveMutation(
-      { tagId: tagId, name: data.name },
+      { tagId: tagId, name: tagInfo.name },
       {
         onSuccess: () =>
           show(
@@ -72,14 +70,14 @@ export const TagBookmarkButton = ({ tagId }: Props) => {
     });
   };
 
-  const handleClick = isFav ? handleDeleteBookmark : handleSaveBookmark;
+  const handleClick = tagInfo.isFav ? handleDeleteBookmark : handleSaveBookmark;
 
   return (
     <div className="fixed bottom-32 left-[50%] translate-x-[-50%] text-center">
       <Button
         id="bookmark"
         className={`ga-search-result-tag-bookmark-click ${
-          isFav
+          tagInfo.isFav
             ? "bg-gray-200 text-gray-600 shadow-[0_0_20px_rgba(38,37,40,0.2)] active:bg-gray-300 active:text-gray-700"
             : "bg-gray-800 text-white active:bg-black active:text-white"
         } ${animation} flex h-53 w-143 justify-between rounded-50 px-24 py-16 text-14-semibold-140`}

--- a/src/pages/explore/keywords/index.tsx
+++ b/src/pages/explore/keywords/index.tsx
@@ -6,7 +6,7 @@ import { NextSeo } from "@/common/components/NextSeo";
 import { PullToRefresh } from "@/common/components/PullToRefresh";
 import { MemeListSkeleton } from "@/common/components/Skeleton";
 import { SSRSuspense } from "@/common/components/Suspense";
-import { DEFAULT_DESCRIPTION, SITE_NAME } from "@/common/utils";
+import { canonicalUrl, DEFAULT_DESCRIPTION, PATH, SITE_NAME } from "@/common/utils";
 import { MemesByKeyword } from "@/features/explore/keywords/components";
 
 interface Props {
@@ -16,7 +16,11 @@ interface Props {
 const ExploreByKeywordPage: NextPage<Props> = ({ keyword }) => {
   return (
     <>
-      <NextSeo title={`'${keyword}' 밈`} {...metadata} />
+      <NextSeo
+        canonical={`${canonicalUrl}${PATH.getExploreByKeywordPath(keyword)}`}
+        title={`'${keyword}' 밈`}
+        {...metadata}
+      />
 
       <ExplorePageNavigation title={keyword} />
       <PullToRefresh>

--- a/src/pages/explore/tags/[tagId].tsx
+++ b/src/pages/explore/tags/[tagId].tsx
@@ -1,13 +1,13 @@
-import { QueryClient } from "@tanstack/react-query";
+import { dehydrate, QueryClient } from "@tanstack/react-query";
 import type { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import { useRouter } from "next/router";
+import { Suspense } from "react";
 
 import { useGetTagInfo } from "@/api/tag";
 import { ExplorePageNavigation } from "@/common/components/Navigation";
 import { NextSeo } from "@/common/components/NextSeo";
 import { PullToRefresh } from "@/common/components/PullToRefresh";
 import { MemeListSkeleton } from "@/common/components/Skeleton";
-import { SSRSuspense } from "@/common/components/Suspense";
 import { canonicalUrl, DEFAULT_DESCRIPTION, PATH, SITE_NAME } from "@/common/utils";
 import { MemesByTagsContainer, TagBookmarkButton } from "@/features/explore/tags/components";
 
@@ -44,13 +44,13 @@ const ExploreByTagPage: NextPage<Props> = ({ tagName, tagId }) => {
       <ExplorePageNavigation title={`#${tagName}`} />
 
       <PullToRefresh>
-        <SSRSuspense fallback={<MemeListSkeleton />}>
+        <Suspense fallback={<MemeListSkeleton />}>
           <MemesByTagsContainer tag={tagName} />
-        </SSRSuspense>
+        </Suspense>
       </PullToRefresh>
-      <SSRSuspense fallback={<></>}>
+      <Suspense>
         <TagBookmarkButton tagId={tagId} />
-      </SSRSuspense>
+      </Suspense>
     </>
   );
 };
@@ -77,6 +77,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
     return {
       props: {
+        hydrateState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
         tagName: tagName,
         tagId: Number(tagId),
       },

--- a/src/pages/explore/tags/[tagId].tsx
+++ b/src/pages/explore/tags/[tagId].tsx
@@ -1,5 +1,6 @@
 import { QueryClient } from "@tanstack/react-query";
 import type { GetStaticPaths, GetStaticProps, NextPage } from "next";
+import { useRouter } from "next/router";
 
 import { useGetTagInfo } from "@/api/tag";
 import { ExplorePageNavigation } from "@/common/components/Navigation";
@@ -16,6 +17,15 @@ interface Props {
 }
 
 const ExploreByTagPage: NextPage<Props> = ({ tagName, tagId }) => {
+  const { isFallback, asPath } = useRouter();
+  const queryString = asPath.split("?")[1];
+  const params = new URLSearchParams(queryString);
+
+  if (isFallback) {
+    const tagName = params.get("q");
+    return <ExplorePageNavigation title={`${tagName ? `#${tagName}` : ""}`} />;
+  }
+
   return (
     <>
       <NextSeo
@@ -48,7 +58,7 @@ const ExploreByTagPage: NextPage<Props> = ({ tagName, tagId }) => {
 export const getStaticPaths: GetStaticPaths = () => {
   return {
     paths: [],
-    fallback: "blocking",
+    fallback: true,
   };
 };
 

--- a/src/pages/explore/tags/[tagId].tsx
+++ b/src/pages/explore/tags/[tagId].tsx
@@ -7,7 +7,7 @@ import { NextSeo } from "@/common/components/NextSeo";
 import { PullToRefresh } from "@/common/components/PullToRefresh";
 import { MemeListSkeleton } from "@/common/components/Skeleton";
 import { SSRSuspense } from "@/common/components/Suspense";
-import { DEFAULT_DESCRIPTION, SITE_NAME } from "@/common/utils";
+import { canonicalUrl, DEFAULT_DESCRIPTION, PATH, SITE_NAME } from "@/common/utils";
 import { MemesByTagsContainer, TagBookmarkButton } from "@/features/explore/tags/components";
 
 interface Props {
@@ -19,6 +19,7 @@ const ExploreByTagPage: NextPage<Props> = ({ tagName, tagId }) => {
   return (
     <>
       <NextSeo
+        canonical={`${canonicalUrl}${PATH.getExploreByTagPath(tagId, tagName)}`}
         description={DEFAULT_DESCRIPTION}
         title={`'${tagName}' 밈`}
         openGraph={{

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,7 +4,7 @@ import { IntroPageNavigation } from "@/common/components/Navigation";
 import type { NextSeoProps } from "@/common/components/NextSeo";
 import { NextSeo } from "@/common/components/NextSeo";
 import { PullToRefresh } from "@/common/components/PullToRefresh";
-import { DEFAULT_DESCRIPTION, SITE_NAME } from "@/common/utils";
+import { canonicalUrl, DEFAULT_DESCRIPTION, SITE_NAME } from "@/common/utils";
 import { MemeListContainer } from "@/features/home/components";
 
 const HomePage: NextPage = () => {
@@ -24,6 +24,7 @@ const metadata: NextSeoProps = {
   title: `${SITE_NAME} : 무한도전 밈 검색`,
   description: DEFAULT_DESCRIPTION,
 
+  canonical: canonicalUrl,
   openGraph: {
     siteName: SITE_NAME,
     imageUrl: `/open-graph/home.png`,

--- a/src/pages/memes/[id].tsx
+++ b/src/pages/memes/[id].tsx
@@ -9,7 +9,7 @@ import { ExplorePageNavigation } from "@/common/components/Navigation";
 import { NextSeo } from "@/common/components/NextSeo";
 import { MemeListSkeleton, Skeleton } from "@/common/components/Skeleton";
 import { SSRSuspense } from "@/common/components/Suspense";
-import { SITE_NAME } from "@/common/utils";
+import { canonicalUrl, SITE_NAME } from "@/common/utils";
 import { useMoveMemeDetail } from "@/features/common";
 import {
   MemeCTAList,
@@ -31,6 +31,7 @@ const MemeDetailPage: NextPage<Props> = ({ id, meme: { name, description, image 
   return (
     <>
       <NextSeo
+        canonical={`${canonicalUrl}/${id}`}
         description={description}
         title={name}
         openGraph={{

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,5 +1,7 @@
 declare namespace NodeJS {
   interface ProcessEnv {
+    NEXT_PUBLIC_CANONICAL_URL: string;
+
     NEXT_PUBLIC_KAKAO_SDK: string;
     NEXT_PUBLIC_API_MOCKING: string;
     NEXT_PUBLIC_API_URL: string;


### PR DESCRIPTION
## ⛳️ 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

- robots.txt 수정
- canonical url 작성
- 태그 검색 결과 페이지 fallback mode 활성화
- getTagInfo query staleTime `infinity`로 수정

## 🌱 PR 포인트
### robots.txt 이슈
![스크린샷 2024-03-08 20 55 42](https://github.com/thismeme-team/thismeme-web/assets/33178048/9b189c07-3818-49f4-86a6-704c9de6af06)
- 상황: https://github.com/thismeme-team/thismeme-web/pull/84 에서 모든 path 에 대해 disallow 를 설정해 검색 엔진 최적화가 안되고 있었음
- 해결: 메인 홈, 밈 상세 페이지, 태그/키워드 검색결과 페이지를 제외한 나머지 path에 대해서만 disallow하도록 수정

### canonical url 설정
- canonical url이란
  - 서비스 내 url 주소는 다르지만 중복된 내용인 경우, 표준 URL을 검색 엔진에게 알려주는 meta data
  - 예를 들어, utm 설정 query string 인 경우 (단지 데이터 수집을 위한 용도로 설정한) query string이 있든 없든 동일한 콘텐츠를 보여주기 때문에 대표 url을 설정해 대표 url에 대해서만 크롤링이 되도록 해줄 수 있다.
  - [만약, 동일한 콘텐츠에 대해 대표 url을 설정하지 않은 경우 엉뚱한 url로 크롤링이 될 수 있기 때문에 설정해주는 편이 좋다.](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls?hl=ko#reasons-to-specify-a-canonical-url)
  - **즉, 검색 엔진에게 동일한 콘텐츠에 대한 여러 url 중 대표 주소를 알려주는 것이다.**

### 태그 검색 결과 페이지 fallback mode 설정
- 상황: 기존에는 `fallback: 'blocking'`으로 설정되어 있어 태그 검색 결과 페이지에 대한 캐시가 없는 경우 오랜 시간 빈 화면을 보아야 한다.
- 개선: fallback 모드를 활성화하고, fallback ui를 보여주는 것으로 대체하였다.
- 단, [`Link` 태그 혹은 `next/router` 를 통해 이동하는 경우(client-side routing)는 `fallback: 'blocking'` 처럼 동작한다](https://arc.net/l/quote/xjpradap)

### getTagInfo query staleTime `infinity`로 수정
- 상황: 태그 정보 query 의 staleTime 이 0으로 설정되어 있었음.
- 개선
  - 태그 검색 결과 페이지 진입 시 서버에서 태그 정보 API 를 prefetch ~~한 후 dehydrate~~ #94 에서 dehydrate 제거
  - 태그 정보 API 는 태그 북마크 추가/해제 시에만 캐시를 바꾸기 때문에 `staleTime` 을 `infinity` 로 설정해둠


## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

- https://developers.google.com/search/docs/crawling-indexing/canonicalization?hl=ko
- https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-true
- [캐노니컬 태그 (Canonical tag)로 검색엔진 최적화하기](https://growthacking.kr/%EC%BA%90%EB%85%B8%EB%8B%88%EC%BB%AC-%ED%83%9C%EA%B7%B8-canonical-tag%EB%A1%9C-%EA%B2%80%EC%83%89%EC%97%94%EC%A7%84-%EC%B5%9C%EC%A0%81%ED%99%94%ED%95%98%EA%B8%B0/)