### PR TITLE
improve: step2 of image optimization

### DIFF
--- a/src/api/search/useGetMemesByTag.ts
+++ b/src/api/search/useGetMemesByTag.ts
@@ -3,14 +3,12 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 
 import { api } from "../core";
 
+const FIRST_PAGE_SIZE = 10;
 const PAGE_SIZE = 20;
 
 /**
  * tag 밈 검색 API
  * @param tag 검색할 tag
- * @returns
- * data - 밈 검색 결과
- * isEmpty - 밈 검색 결과가 없는 경우 true
  */
 export const useGetMemesByTag = (tag: string) => {
   const {
@@ -18,20 +16,39 @@ export const useGetMemesByTag = (tag: string) => {
     isFetchingNextPage,
     isError,
     fetchNextPage: originalFetchNextPage,
-  } = useInfiniteQuery(
-    useGetMemesByTag.queryKey(tag),
-    ({ pageParam = 0 }: QueryFunctionContext) =>
-      api.search.getMemesByTag({ keyword: tag, offset: pageParam, limit: PAGE_SIZE }),
-    {
-      getNextPageParam: (lastPage, allPages) => {
-        const { count } = lastPage;
-        const isLastPage = count < PAGE_SIZE;
-        const offset = count * (allPages.length - 1);
-        return isLastPage ? undefined : offset + PAGE_SIZE;
-      },
-      enabled: !!tag,
+  } = useInfiniteQuery({
+    queryKey: useGetMemesByTag.queryKey(tag),
+    queryFn: ({ pageParam = 0 }: QueryFunctionContext) =>
+      api.search.getMemesByTag({
+        keyword: tag,
+        offset: pageParam,
+        limit: pageParam === 0 ? FIRST_PAGE_SIZE : PAGE_SIZE,
+      }),
+    select: (data) => {
+      return {
+        ...data,
+        pages: data.pages.map((page, index) => {
+          const isFirstPage = index === 0;
+          return {
+            ...page,
+            memes: page.memes.map((meme, index) => ({
+              ...meme,
+              priority: isFirstPage && index < 4,
+            })),
+          };
+        }),
+      };
     },
-  );
+    getNextPageParam: (lastPage, allPages) => {
+      const { count } = lastPage;
+      const isFirstPage = allPages.length === 1;
+      const pageSize = isFirstPage ? FIRST_PAGE_SIZE : PAGE_SIZE;
+      const isLastPage = count < pageSize;
+      const offset = count * (allPages.length - 1);
+      return isLastPage ? undefined : offset + pageSize;
+    },
+    enabled: !!tag,
+  });
 
   const fetchNextPage = isError
     ? ((() => {}) as typeof originalFetchNextPage)

--- a/src/common/components/Photo/Photo.tsx
+++ b/src/common/components/Photo/Photo.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from "react";
  * storybook jsdoc parse 오류 발생. interface 내부에 @deprecated 어노테이션이 있으면 문제 생기는 듯 보임
  * storybook v7으로 업그레이드 시 문제 발생하는지 확인해야 함
  */
-interface Props extends ComponentProps<typeof Image> {
+interface Props extends Omit<ComponentProps<typeof Image>, "style"> {
   fallbackSrc?: string;
 }
 const base64Blur =
@@ -52,7 +52,7 @@ export const Photo = ({
         placeholder="blur"
         sizes=" "
         src={isFailLoading ? fallbackSrc : src}
-        style={{ objectFit: "cover" }}
+        style={{ objectFit: "cover", transform: "translate3d(0, 0, 0)" }}
         onError={setIsFailLoading}
         {...props}
       />

--- a/src/features/common/components/MemeItem.tsx
+++ b/src/features/common/components/MemeItem.tsx
@@ -34,15 +34,16 @@ export const MemeItem = memo(({ meme, onClick }: Props) => {
           draggable={false}
           height={image.images[0]?.imageHeight}
           loader={cloudinaryLoader}
+          loading={meme.priority ? "eager" : "lazy"}
           sizes="200px"
           src={image.images[0]?.imageUrl}
           unoptimized={isEncodingError(image.images[0]?.imageUrl)}
           width={image.images[0]?.imageWidth}
         />
       </button>
-      <div className="flex justify-between gap-6">
+      <div className="flex justify-between">
         <button
-          className="ga-meme-item-click py-4 text-start"
+          className="ga-meme-item-click flex-1 py-4 text-start"
           onClick={() => {
             onClick?.(memeId);
             movePage(memeId);
@@ -51,7 +52,7 @@ export const MemeItem = memo(({ meme, onClick }: Props) => {
           <span className="text-12-medium-160 line-clamp-2">{name}</span>
         </button>
         <button
-          className="ga-meme-item-add-click flex h-32 w-32 justify-center"
+          className="ga-meme-item-add-click flex h-32 w-32 items-center justify-center"
           onClick={() => {
             overlay.open(({ isOpen, close }) => (
               <MemeActionSheet isOpen={isOpen} meme={meme} onClose={close} />


### PR DESCRIPTION
## 📮 관련 이슈
- related #82 

## ⛳️ 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

- 이미지 렌더링 시 gpu 가속을 사용할 수 있도록 개선(`transform: translate3d()` 사용)
- 태그 검색 페이지에서 썸네일과 4개의 밈 아이템만 지연 로드 제거

## 🌱 PR 포인트

### LCP에 대한 지연 로드 제거

- 상황: 밈 이미지가 모드 지연로드 되고 있음. **즉, LCP 요소에 지연로드가 들어가고 있음**
- 해결: [LCP에 대한 지연 로드를 제거하기 위해](https://arc.net/l/quote/anuenbax) 태그 검색 결과 페이지에서 썸네일과 4개의 밈 아이템만 지연로드 제거
- 고민: 메인 홈, 키워드 검색 페이지에도 4개의 밈 아이템에도 지연 로드를 제거해줄 필요가 있음. 그러기 위해서는 `useCoreInfiniteQuery` 에 대한 리팩터링이 이루어져야 함.

## 참고

- [Build a fast, animated image gallery with Next.js – Vercel](https://vercel.com/blog/building-a-fast-animated-image-gallery-with-next-js#using-the-next.js-image-component)
- [Optimize Largest Contentful Paint  |  Articles  |  web.dev](https://web.dev/articles/optimize-lcp#eliminate-resource-load-delay)