### PR TITLE
improve: step3 of image optimization

### DIFF
--- a/src/features/common/components/TagCategory/CategoryContent.tsx
+++ b/src/features/common/components/TagCategory/CategoryContent.tsx
@@ -68,7 +68,6 @@ export const CategoryContent = () => {
                   unoptimized
                   alt={category.name}
                   className="h-24 w-24 p-2"
-                  loading="eager"
                   src={category.icon}
                 />
                 <span className="flex-grow text-left text-16-semibold-140">

--- a/src/features/common/components/TagCategory/FavoriteCategory.tsx
+++ b/src/features/common/components/TagCategory/FavoriteCategory.tsx
@@ -65,13 +65,7 @@ export const FavoriteCategory = () => {
       <Item value={FAVORITE_ID}>
         <Header className="py-4">
           <Trigger className="flex w-full items-center justify-between gap-8 rounded-full px-4 py-12 text-16-semibold-140 [&>span>#chevronDown]:data-[state=open]:rotate-180">
-            <Photo
-              unoptimized
-              alt="북마크"
-              className="h-24 w-24 p-2"
-              loading="eager"
-              src={FAVORITE_ICON}
-            />
+            <Photo unoptimized alt="북마크" className="h-24 w-24 p-2" src={FAVORITE_ICON} />
             <span className="flex-grow text-left text-16-semibold-140">{FAVORITE_ID}</span>
             <span className="flex h-40 w-40 items-center justify-center rounded-full hover:bg-gray-100">
               <Icon


### PR DESCRIPTION
# ⛳️ 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

#82 

- 태그 카테고리 관련 아이콘들 레이지 로딩 적용

## 🌱 PR 포인트

### 태그 카테고리 아이콘 lazy loading 적용
- 상황: 태그 카테고리 아이콘이 화면에 바로 보이지 않음에도 레이지 로딩 되고 있지 않아 밈 콘텐츠 사진(LCP)의 로드 우선순위가 낮게(low) 잡히게 됨
- 해결: 태그 카테고리 아이콘에 lazy loading 을 적용하여 밈 콘텐츠 사진 우선순위를 높임(high)

#### AS-IS

![스크린샷 2024-03-29 20 47 27](https://github.com/thismeme-team/thismeme-web/assets/33178048/fc9c6ab8-34c3-486d-ba2f-7e2a330cbc1d)

#### TO-BE

![스크린샷 2024-03-29 20 48 23](https://github.com/thismeme-team/thismeme-web/assets/33178048/dfc7cec4-c141-4c4b-93bd-2e88177d9bce)
