### PR TITLE
fix: invisible tag bookmark button initially

### DIFF
--- a/src/api/tag/useGetTagInfo.ts
+++ b/src/api/tag/useGetTagInfo.ts
@@ -7,6 +7,7 @@ export const useGetTagInfo = (tagId: number) => {
     queryKey: useGetTagInfo.queryKey(tagId),
     queryFn: () => useGetTagInfo.queryFn(tagId),
     staleTime: Infinity,
+    refetchOnMount: "always",
   });
 };
 

--- a/src/api/tag/useGetTagInfo.ts
+++ b/src/api/tag/useGetTagInfo.ts
@@ -1,16 +1,12 @@
-import type { QueryClient, UseQueryOptions } from "@tanstack/react-query";
+import type { QueryClient } from "@tanstack/react-query";
 
 import { api, useSuspendedQuery } from "../core";
 
-export const useGetTagInfo = (
-  tagId: number,
-  options: Pick<UseQueryOptions, "enabled"> = { enabled: true },
-) => {
+export const useGetTagInfo = (tagId: number) => {
   return useSuspendedQuery({
     queryKey: useGetTagInfo.queryKey(tagId),
     queryFn: () => useGetTagInfo.queryFn(tagId),
     staleTime: Infinity,
-    ...options,
   });
 };
 

--- a/src/features/explore/tags/components/TagBookmarkButton.tsx
+++ b/src/features/explore/tags/components/TagBookmarkButton.tsx
@@ -13,16 +13,12 @@ const TAG_DELAY = 1500;
 
 export const TagBookmarkButton = ({ tagId }: Props) => {
   const { show, close } = useToast();
-  const { validate, isLoading } = useAuth();
-  const { data: tagInfo, isFetchedAfterMount } = useGetTagInfo(tagId, { enabled: !isLoading });
+  const { validate } = useAuth();
+  const { data: tagInfo } = useGetTagInfo(tagId);
 
   const { mutate: saveMutation } = usePostFavoriteTag();
   const { mutate: deleteMutation, onCancel } = useDeleteFavoriteTag(TAG_DELAY);
   const [, setIsOpenTagCategory] = useTagCategoryContext();
-
-  if (!isFetchedAfterMount || !tagInfo) {
-    return null;
-  }
 
   const handleSaveBookmark = () => {
     saveMutation(


### PR DESCRIPTION
## ⛳️ 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

- 태그 검색 결과 페이지에 처음 진입할 때 북마크 버튼이 보이지 않는 이슈 해결

## PR Point
### 태그 정보 쿼리에 `refetchOnMount: 'always'` 추가 이유
다음 use case 를 고려하였습니다.
1. client-side 라우팅할 때,

    - 태그/카테고리 -> 태그 클릭 -> 태그 검색 결과
    - 밈 상세 -> 태그 클릭 -> 태그 검색 결과

2. 로그인 후 태그 검색 결과 페이지로 들어올 때,

태그 검색 결과 페이지로 돌아오게 되면 (mount 되므로) 항상 refetch 하도록 하였습니다