### PR TITLE
fix: duplicated request taginfo

### DIFF
--- a/src/api/tag/useGetTagInfo.ts
+++ b/src/api/tag/useGetTagInfo.ts
@@ -7,7 +7,6 @@ export const useGetTagInfo = (tagId: number) => {
     queryKey: useGetTagInfo.queryKey(tagId),
     queryFn: () => useGetTagInfo.queryFn(tagId),
     staleTime: Infinity,
-    refetchOnMount: "always",
   });
 };
 

--- a/src/common/utils/path.ts
+++ b/src/common/utils/path.ts
@@ -15,9 +15,7 @@ export const PATH = {
    * @param tagName - 태그 이름
    * @return /explore/tags/${tagId}?q={tagName}
    */
-  getExploreByTagPath: (tagId: number, tagName?: string) => {
-    if (!tagName) return `/explore/tags/${tagId}`;
-
+  getExploreByTagPath: (tagId: number, tagName: string) => {
     const encodedValue = encodeURIComponent(tagName);
     return `/explore/tags/${tagId}?q=${encodedValue}`;
   },

--- a/src/pages/explore/tags/[tagId].tsx
+++ b/src/pages/explore/tags/[tagId].tsx
@@ -1,5 +1,4 @@
 import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
-import { useRouter } from "next/router";
 
 import { ExplorePageNavigation } from "@/common/components/Navigation";
 import { NextSeo } from "@/common/components/NextSeo";
@@ -18,15 +17,6 @@ const ExploreByTagPage = ({
   tagName,
   tagId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  const { isFallback, asPath } = useRouter();
-  const queryString = asPath.split("?")[1];
-  const params = new URLSearchParams(queryString);
-
-  if (isFallback) {
-    const tagName = params.get("q");
-    return <ExplorePageNavigation title={`${tagName ? `#${tagName}` : ""}`} />;
-  }
-
   return (
     <>
       <NextSeo

--- a/src/pages/explore/tags/[tagId].tsx
+++ b/src/pages/explore/tags/[tagId].tsx
@@ -47,7 +47,7 @@ const ExploreByTagPage = ({
 };
 
 export const getServerSideProps: GetServerSideProps = (async ({ res, params, query }) => {
-  res.setHeader("Cache-Control", "public, s-maxage=200, stale-while-revalidate=59");
+  res.setHeader("Cache-Control", "public, s-maxage=604800, stale-while-revalidate=86400");
 
   const tagName = query.q;
   const tagId = params?.tagId;


### PR DESCRIPTION
## ⛳️ 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

- 태그 정보 API 중복 요청 제거
- 태그 검색 결과 페이지에서 ISR에서 cached SSR로 변경

## 트러블 슈팅

### 태그 정보 API 중복 요청 발생
#### 상황
#103 에서 `refetchOnMount: 'always'` 설정 후 태그 정보 API가 2번 요청됨. 즉, `getStaticProps` 에서 1번, 클라이언트에서 2번, 총 3번의 API 중복이 발생함

#### 해결
태그 정보 API는 클라이언트에서만 요청하여 중복 요청 제거

#### 문제점 및 개선할 점
태그 검색 결과 페이지의 메타데이터 설정을 위해 태그 정보를 서버에서 받아서 HTML로 그려주어야 했음. 그러나 서버에서 태그 정보를 불러오지 않으면 메타데이터를 설정해줄 방법이 없음. **query string에 태그 이름을 받긴 하지만 getStaticProps에서는 페이지 요청 시 설정한 query string에 접근할 수 없음. 그래서 불가피하게 SSR로 변경이 필요했음**

### ISR에서 SSR(w/ cache)로 변경
#### 상황
- 태그 정보 API가 서버와 클라이언트에서 각각 중복요청이 발생함
- 서버에서만 받아 page 컴포넌트 props로 내려주자니 태그 검색 결과 페이지가 SSG를 이용하기 때문에 cache 되어 태그 정보"만" refetch 할 방법이 없음.
- SSR 하자니 페이지를 요청할 때마다 서버에 요청하기에 서버 부하와 속도 저하 문제가 있음

#### 해결
- SSR의 결과를 cache하도록 설정 (`max-age` 7일, `stale-while-revalidate` 1일 설정)
```ts
export const getServerSideProps: GetServerSideProps = async ({ res, params, query }) => {
  res.setHeader("Cache-Control", "public, s-maxage=604800, stale-while-revalidate=86400");
  ...
};
```

#### 문제점 및 개선할 점

- **Page Router의 한계인 route 단위로"만" 서버사이드 렌더링이 가능하다는 점이 느껴짐**
- 컴포넌트 단위의 SSR이 가능하다면, 태그 정보 API를 사용하는 컴포넌트와 페이지 컴포넌트를 따로 SSR 할 수 있다는 생각이 듦
- App Router 로 전환할 필요를 느낌

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

[Caching with Server-Side Rendering (SSR)](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props#caching-with-server-side-rendering-ssr)